### PR TITLE
fix: consistent launch on login menu item

### DIFF
--- a/Soduto/Core/Configuration/Configuration.swift
+++ b/Soduto/Core/Configuration/Configuration.swift
@@ -340,6 +340,12 @@ public class Configuration: ConnectionConfiguration, DeviceManagerConfiguration,
                 let loginItem = SMAppService.mainApp
                 switch (loginItem.status) {
                 case SMAppService.Status.notRegistered, SMAppService.Status.notFound:
+                    // Request to turn off, but already unregistered
+                    if !newValue {
+                        self.userDefaults.set(false, forKey: Property.launchOnLogin.rawValue)
+                        break
+                    }
+                    // Request to turn on
                     if ((try? loginItem.register()) != nil) {
                         self.userDefaults.set(true, forKey: Property.launchOnLogin.rawValue)
                     } else {
@@ -349,6 +355,12 @@ public class Configuration: ConnectionConfiguration, DeviceManagerConfiguration,
                     }
                     break
                 case SMAppService.Status.enabled:
+                    // Request to turn on, but already registered
+                    if newValue {
+                        self.userDefaults.set(true, forKey: Property.launchOnLogin.rawValue)
+                        break
+                    }
+                    // Request to turn off
                     if ((try? loginItem.unregister()) != nil) {
                         self.userDefaults.set(false, forKey: Property.launchOnLogin.rawValue)
                     } else {
@@ -358,10 +370,17 @@ public class Configuration: ConnectionConfiguration, DeviceManagerConfiguration,
                     }
                     break
                 case SMAppService.Status.requiresApproval:
+                    // Request to turn off, but not registered (requires approval)
+                    if !newValue {
+                        self.userDefaults.set(false, forKey: Property.launchOnLogin.rawValue)
+                        break
+                    }
+                    // Request to turn on
                     SMAppService.openSystemSettingsLoginItems()
                     self.notification.ShowCustomNotification(title: "Uh'oh!", body: "macOS requires approval to let Soduto change login item settings. Tap the + icon and add 'Soduto' manually", sound: true, id: "LoginItemApproval")
                     break
-                default: break
+                default:
+                    break
                 }
             } else {
                 if SMLoginItemSetEnabled("com.soduto.SodutoLauncher" as CFString, newValue) {

--- a/Soduto/Core/Configuration/Configuration.swift
+++ b/Soduto/Core/Configuration/Configuration.swift
@@ -338,8 +338,8 @@ public class Configuration: ConnectionConfiguration, DeviceManagerConfiguration,
         set {
             if #available(macOS 13.0, *) {
                 let loginItem = SMAppService.mainApp
-                switch (loginItem.status.rawValue) {
-                case 0:
+                switch (loginItem.status) {
+                case SMAppService.Status.notRegistered, SMAppService.Status.notFound:
                     if ((try? loginItem.register()) != nil) {
                         self.userDefaults.set(true, forKey: Property.launchOnLogin.rawValue)
                     } else {
@@ -348,7 +348,7 @@ public class Configuration: ConnectionConfiguration, DeviceManagerConfiguration,
                         SMAppService.openSystemSettingsLoginItems()
                     }
                     break
-                case 1:
+                case SMAppService.Status.enabled:
                     if ((try? loginItem.unregister()) != nil) {
                         self.userDefaults.set(false, forKey: Property.launchOnLogin.rawValue)
                     } else {
@@ -357,12 +357,9 @@ public class Configuration: ConnectionConfiguration, DeviceManagerConfiguration,
                         SMAppService.openSystemSettingsLoginItems()
                     }
                     break
-                case 2:
+                case SMAppService.Status.requiresApproval:
                     SMAppService.openSystemSettingsLoginItems()
                     self.notification.ShowCustomNotification(title: "Uh'oh!", body: "macOS requires approval to let Soduto change login item settings. Tap the + icon and add 'Soduto' manually", sound: true, id: "LoginItemApproval")
-                    break
-                case 3:
-                    print("SMAppService not found!")
                     break
                 default: break
                 }

--- a/Soduto/UI/Controllers/StatusBarMenuController.swift
+++ b/Soduto/UI/Controllers/StatusBarMenuController.swift
@@ -132,11 +132,11 @@ public class StatusBarMenuController: NSObject, NSWindowDelegate, NSMenuDelegate
                 let loginItem = SMAppService.mainApp
                 var enabled = self.config?.launchOnLogin ?? false
                 switch (loginItem.status) {
-                case SMAppService.Status.notFound, SMAppService.Status.notRegistered, SMAppService.Status.requiresApproval:
+                case .notFound, .notRegistered, .requiresApproval:
                     self.launchOnLoginItem.state = NSControl.StateValue.off
                     enabled = false
                     break
-                case SMAppService.Status.enabled:
+                case .enabled:
                     self.launchOnLoginItem.state = NSControl.StateValue.on
                     enabled = true
                     break

--- a/Soduto/UI/Controllers/StatusBarMenuController.swift
+++ b/Soduto/UI/Controllers/StatusBarMenuController.swift
@@ -129,11 +129,11 @@ public class StatusBarMenuController: NSObject, NSWindowDelegate, NSMenuDelegate
             self.refreshMenuDeviceList()
             if #available(macOS 13.0, *) {
                 let loginItem = SMAppService.mainApp
-                switch (loginItem.status.rawValue) {
-                case 0:
+                switch (loginItem.status) {
+                case SMAppService.Status.notFound, SMAppService.Status.notRegistered, SMAppService.Status.requiresApproval:
                     self.launchOnLoginItem.state = NSControl.StateValue.off
                     break
-                case 1:
+                case SMAppService.Status.enabled:
                     self.launchOnLoginItem.state = NSControl.StateValue.on
                     break
                 default:

--- a/Soduto/UI/Controllers/StatusBarMenuController.swift
+++ b/Soduto/UI/Controllers/StatusBarMenuController.swift
@@ -9,6 +9,7 @@
 import Foundation
 import AppKit
 import ServiceManagement
+import CleanroomLogger
 
 public class StatusBarMenuController: NSObject, NSWindowDelegate, NSMenuDelegate, NSDraggingDestination {
     
@@ -129,16 +130,23 @@ public class StatusBarMenuController: NSObject, NSWindowDelegate, NSMenuDelegate
             self.refreshMenuDeviceList()
             if #available(macOS 13.0, *) {
                 let loginItem = SMAppService.mainApp
+                var enabled = self.config?.launchOnLogin ?? false
                 switch (loginItem.status) {
                 case SMAppService.Status.notFound, SMAppService.Status.notRegistered, SMAppService.Status.requiresApproval:
                     self.launchOnLoginItem.state = NSControl.StateValue.off
+                    enabled = false
                     break
                 case SMAppService.Status.enabled:
                     self.launchOnLoginItem.state = NSControl.StateValue.on
+                    enabled = true
                     break
                 default:
                     self.launchOnLoginItem.state = NSControl.StateValue.mixed
                     break
+                }
+                if self.config?.launchOnLogin != enabled {
+                    Log.debug?.message("Updated launchOnLogin state: \(enabled)")
+                    self.config?.launchOnLogin = enabled
                 }
             } else {
                 self.launchOnLoginItem.state = (self.config?.launchOnLogin ?? false) ? NSControl.StateValue.on : NSControl.StateValue.off


### PR DESCRIPTION
According to [Apple's doc](https://developer.apple.com/documentation/servicemanagement/smappservice/status-swift.enum/notfound) `SMAppService.Status.notFound` should only be returned when there's an error, but for some reason it is returned when the service is not registered. This PR treats `notFound` the same as `notRegistered`, and simplifies menu item state.