### PR TITLE
feat(share-extension): add support for multi-device sharing flow in soduto share

### DIFF
--- a/SharedUserDefaults.swift
+++ b/SharedUserDefaults.swift
@@ -20,6 +20,13 @@ enum AppDefaultsStore {
     // MARK: - Share Extension Communication
     
     enum ShareExtension {
+        /// Timestamp (timeIntervalSince1970) of the last heartbeat from the main app.
+        /// Written periodically by the main app; read by the extension to detect crashes.
+        static var appLastHeartbeat: TimeInterval {
+            get { appGroupDefaults?.double(forKey: "com.soduto.share.appLastHeartbeat") ?? 0 }
+            set { appGroupDefaults?.set(newValue, forKey: "com.soduto.share.appLastHeartbeat") }
+        }
+        
         static var reachableDevices: [[String: String]] {
             get { appGroupDefaults?.object(forKey: "com.soduto.share.reachableDevices") as? [[String: String]] ?? [] }
             set { appGroupDefaults?.set(newValue, forKey: "com.soduto.share.reachableDevices") }
@@ -39,7 +46,7 @@ enum AppDefaultsStore {
             get { appGroupDefaults?.stringArray(forKey: "com.soduto.share.sharedTexts") }
             set { appGroupDefaults?.set(newValue, forKey: "com.soduto.share.sharedTexts") }
         }
-
+        
         /// Transfer status per device for the current share session.
         /// Maps device ID -> status: "success", "failed". Written by main app, read by extension.
         static var transferStatuses: [String: String]? {

--- a/SharedUserDefaults.swift
+++ b/SharedUserDefaults.swift
@@ -39,6 +39,13 @@ enum AppDefaultsStore {
             get { appGroupDefaults?.stringArray(forKey: "com.soduto.share.sharedTexts") }
             set { appGroupDefaults?.set(newValue, forKey: "com.soduto.share.sharedTexts") }
         }
+
+        /// Transfer status per device for the current share session.
+        /// Maps device ID -> status: "success", "failed". Written by main app, read by extension.
+        static var transferStatuses: [String: String]? {
+            get { appGroupDefaults?.dictionary(forKey: "com.soduto.share.transferStatuses") as? [String: String] }
+            set { appGroupDefaults?.set(newValue, forKey: "com.soduto.share.transferStatuses") }
+        }
     }
     
     

--- a/Soduto Share/Controllers/ShareExtensionController+TouchBar.swift
+++ b/Soduto Share/Controllers/ShareExtensionController+TouchBar.swift
@@ -11,8 +11,8 @@ import Cocoa
 extension ShareExtensionController: NSTouchBarDelegate, NSScrubberDataSource, NSScrubberDelegate, NSScrubberFlowLayoutDelegate {
     
     static let scrubberItemId = NSUserInterfaceItemIdentifier("DeviceItem")
-    static let cancelItemId = NSTouchBarItem.Identifier("com.soduto.Soduto.share.touchbar.cancel")
-    static let devicesItemId = NSTouchBarItem.Identifier("com.soduto.Soduto.share.touchbar.devices")
+    static let cancelItemId = NSTouchBarItem.Identifier("com.soduto.soduto.share.touchbar.cancel")
+    static let devicesItemId = NSTouchBarItem.Identifier("com.soduto.soduto.share.touchbar.devices")
     
     // MARK: - NSTouchBar
     

--- a/Soduto Share/Controllers/ShareExtensionController+TouchBar.swift
+++ b/Soduto Share/Controllers/ShareExtensionController+TouchBar.swift
@@ -79,6 +79,10 @@ extension ShareExtensionController: NSTouchBarDelegate, NSScrubberDataSource, NS
     // MARK: - NSScrubberDelegate
     
     func scrubber(_ scrubber: NSScrubber, didSelectItemAt index: Int) {
+        guard viewModel.isInteractive(index) else {
+            scrubber.selectedIndex = -1
+            return
+        }
         shareToDevice(at: index)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
             scrubber.selectedIndex = -1

--- a/Soduto Share/Controllers/ShareExtensionController+TouchBar.swift
+++ b/Soduto Share/Controllers/ShareExtensionController+TouchBar.swift
@@ -51,6 +51,8 @@ extension ShareExtensionController: NSTouchBarDelegate, NSScrubberDataSource, NS
             layout.itemSpacing = 8
             scrubber.scrubberLayout = layout
             
+            self.touchBarScrubber = scrubber
+            
             let item = NSCustomTouchBarItem(identifier: identifier)
             item.view = scrubber
             return item
@@ -73,6 +75,7 @@ extension ShareExtensionController: NSTouchBarDelegate, NSScrubberDataSource, NS
             name: entry["name"] ?? "Unknown Device",
             symbolName: sfSymbolName(for: entry["type"] ?? "unknown")
         )
+        view.isDisabledVisually = !viewModel.isInteractive(index)
         return view
     }
     

--- a/Soduto Share/Controllers/ShareExtensionController.swift
+++ b/Soduto Share/Controllers/ShareExtensionController.swift
@@ -18,6 +18,8 @@ class ShareExtensionController: NSViewController {
     /// Each entry is ["id": "<deviceId>", "name": "<displayName>", "type": "<deviceType>"]
     var validDeviceEntries: [[String: String]] = AppDefaultsStore.ShareExtension.reachableDevices
     
+    lazy var viewModel = ShareViewModel(deviceCount: validDeviceEntries.count)
+    
     // MARK: - NSViewController
     
     /// Computes a sheet height that fits the content, capped at a maximum.
@@ -35,10 +37,18 @@ class ShareExtensionController: NSViewController {
     }
     
     override func loadView() {
-        let rootView = ShareSheetView(deviceEntries: validDeviceEntries, onDeviceSelected: { [weak self] index in
+        // Clear any stale transfer statuses from a previous session
+        AppDefaultsStore.ShareExtension.transferStatuses = nil
+        
+        let rootView = ShareSheetView(viewModel: viewModel, deviceEntries: validDeviceEntries, onDeviceSelected: { [weak self] index in
             self?.shareToDevice(at: index)
-        }, onCancel: { [weak self] in
-            self?.cancel(nil)
+        }, onDismiss: { [weak self] in
+            guard let self = self else { return }
+            if self.viewModel.hasInitiatedAnyShare {
+                self.extensionContext?.completeRequest(returningItems: [], completionHandler: nil)
+            } else {
+                self.cancel(nil)
+            }
         })
         
         let height = sheetHeight
@@ -61,6 +71,16 @@ class ShareExtensionController: NSViewController {
         } else {
             logger.debug("No Attachments")
         }
+        
+        // Register for reverse Darwin notifications from main app (transfer status updates)
+        let statusNotificationName = "com.Soduto.Share.Status" as CFString
+        CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), Unmanaged.passUnretained(self).toOpaque(), { _, observer, _, _, _ in
+            guard let observer = observer else { return }
+            let controller = Unmanaged<ShareExtensionController>.fromOpaque(observer).takeUnretainedValue()
+            DispatchQueue.main.async {
+                controller.handleStatusUpdate()
+            }
+        }, statusNotificationName, nil, .deliverImmediately)
     }
     
     override func viewDidAppear() {
@@ -71,25 +91,49 @@ class ShareExtensionController: NSViewController {
     
     deinit {
         self.view.window?.unbind(NSBindingName(rawValue: #keyPath(touchBar)))
+        CFNotificationCenterRemoveObserver(CFNotificationCenterGetDarwinNotifyCenter(), Unmanaged.passUnretained(self).toOpaque(), nil, nil)
+        AppDefaultsStore.ShareExtension.transferStatuses = nil
     }
     
     // MARK: - Share Logic
     
     func shareToDevice(at index: Int) {
-        guard let content = extensionContext?.inputItems.first as? NSExtensionItem else {
-            self.extensionContext!.completeRequest(returningItems: [], completionHandler: nil)
-            return
-        }
+        // Guard: device must be interactive
+        guard viewModel.isInteractive(index) else { return }
         
-        guard index < self.validDeviceEntries.count else {
+        // Guard: valid index
+        guard index < validDeviceEntries.count else {
             UserNotificationHelper.show(title: "Soduto Share", body: "Selected device is no longer available.", sound: true, id: "DeviceUnavailable", urgency: .active)
-            self.extensionContext!.completeRequest(returningItems: [], completionHandler: nil)
             return
         }
-        let selectedDevice = self.validDeviceEntries[index]["id"] ?? ""
-        AppDefaultsStore.ShareExtension.selectedDevice = selectedDevice
         
-        // Use a DispatchGroup to wait for all async loadItem calls to complete before dismissing the extension
+        // Guard: not currently collecting attachments (prevents race on first tap)
+        guard !viewModel.isCollectingAttachments else { return }
+        
+        // Set transferring state (breathing ring appears)
+        viewModel.deviceStatuses[index] = .transferring
+        
+        if viewModel.cachedBookmarks != nil {
+            // Attachments already cached — hand off immediately
+            handOffToMainApp(deviceIndex: index)
+        } else {
+            // First tap — collect attachments, then hand off
+            collectAttachmentsThenHandOff(deviceIndex: index)
+        }
+    }
+    
+    @objc func cancel(_ sender: AnyObject?) {
+        let cancelError = NSError(domain: NSCocoaErrorDomain, code: NSUserCancelledError, userInfo: nil)
+        self.extensionContext!.cancelRequest(withError: cancelError)
+    }
+    
+    // MARK: - Attachment Collection
+    
+    private func collectAttachmentsThenHandOff(deviceIndex: Int) {
+        guard let content = extensionContext?.inputItems.first as? NSExtensionItem else { return }
+        
+        viewModel.isCollectingAttachments = true
+        
         let group = DispatchGroup()
         let lock = NSLock()
         var collectedBookmarks: [Data] = []
@@ -146,25 +190,66 @@ class ShareExtensionController: NSViewController {
             }
         }
         
-        // Wait for all async attachment loads, then store results and notify the main app
-        group.notify(queue: .main) {
-            if !collectedBookmarks.isEmpty {
-                AppDefaultsStore.ShareExtension.fileBookmarkData = collectedBookmarks
-            }
-            if !collectedTexts.isEmpty {
-                AppDefaultsStore.ShareExtension.sharedTexts = collectedTexts
-            }
-            if !collectedBookmarks.isEmpty || !collectedTexts.isEmpty {
-                self.notifyMainApp()
-            }
-            self.extensionContext!.completeRequest(returningItems: [], completionHandler: nil)
+        group.notify(queue: .main) { [weak self] in
+            guard let self = self else { return }
+            
+            // Cache for reuse on subsequent device taps
+            self.viewModel.cachedBookmarks = collectedBookmarks
+            self.viewModel.cachedTexts = collectedTexts
+            self.viewModel.isCollectingAttachments = false
+            
+            self.handOffToMainApp(deviceIndex: deviceIndex)
         }
     }
     
-    @objc func cancel(_ sender: AnyObject?) {
-        let cancelError = NSError(domain: NSCocoaErrorDomain, code: NSUserCancelledError, userInfo: nil)
-        self.extensionContext!.cancelRequest(withError: cancelError)
+    // MARK: - Handoff to Main App
+    
+    private func handOffToMainApp(deviceIndex: Int) {
+        let selectedDevice = validDeviceEntries[deviceIndex]["id"] ?? ""
+        
+        // Clear any previous status for this device (important for retries)
+        var statuses = AppDefaultsStore.ShareExtension.transferStatuses ?? [:]
+        statuses.removeValue(forKey: selectedDevice)
+        AppDefaultsStore.ShareExtension.transferStatuses = statuses
+        
+        // Write device ID
+        AppDefaultsStore.ShareExtension.selectedDevice = selectedDevice
+        
+        // Write cached attachment data
+        let bookmarks = viewModel.cachedBookmarks ?? []
+        let texts = viewModel.cachedTexts ?? []
+        
+        if !bookmarks.isEmpty {
+            AppDefaultsStore.ShareExtension.fileBookmarkData = bookmarks
+        }
+        if !texts.isEmpty {
+            AppDefaultsStore.ShareExtension.sharedTexts = texts
+        }
+        
+        // Notify the main app only if there is data to share
+        if !bookmarks.isEmpty || !texts.isEmpty {
+            notifyMainApp()
+        }
     }
+    
+    // MARK: - Status Updates from Main App
+    
+    func handleStatusUpdate() {
+        guard let statuses = AppDefaultsStore.ShareExtension.transferStatuses else { return }
+        for (index, entry) in validDeviceEntries.enumerated() {
+            guard let deviceId = entry["id"], let status = statuses[deviceId] else { continue }
+            switch status {
+            case "success":
+                viewModel.deviceStatuses[index] = .sent
+            case "failed":
+                viewModel.deviceStatuses[index] = .failed
+            default:
+                break
+            }
+        }
+    }
+    
+    // MARK: - Private Helpers
     
     private func notifyMainApp() {
         let notificationName = CFNotificationName("com.Soduto.Share" as CFString)

--- a/Soduto Share/Controllers/ShareExtensionController.swift
+++ b/Soduto Share/Controllers/ShareExtensionController.swift
@@ -15,8 +15,13 @@ private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.sodu
 
 class ShareExtensionController: NSViewController {
     
-    /// Each entry is ["id": "<deviceId>", "name": "<displayName>", "type": "<deviceType>"]
-    var validDeviceEntries: [[String: String]] = AppDefaultsStore.ShareExtension.reachableDevices
+    /// Each entry is ["id": "<deviceId>", "name": "<displayName>", "type": "<deviceType>"].
+    /// Returns an empty list if the main app's heartbeat is stale (app not running or crashed).
+    var validDeviceEntries: [[String: String]] = {
+        let heartbeat = AppDefaultsStore.ShareExtension.appLastHeartbeat
+        guard Date().timeIntervalSince1970 - heartbeat < 60 else { return [] }
+        return AppDefaultsStore.ShareExtension.reachableDevices
+    }()
     
     lazy var viewModel = ShareViewModel(deviceCount: validDeviceEntries.count)
     

--- a/Soduto Share/Controllers/ShareExtensionController.swift
+++ b/Soduto Share/Controllers/ShareExtensionController.swift
@@ -7,6 +7,7 @@
 //
 
 import Cocoa
+import Combine
 import SwiftUI
 import UniformTypeIdentifiers
 import os.log
@@ -24,6 +25,8 @@ class ShareExtensionController: NSViewController {
     }()
     
     lazy var viewModel = ShareViewModel(deviceCount: validDeviceEntries.count)
+    weak var touchBarScrubber: NSScrubber?
+    private var touchBarStatusCancellable: AnyCancellable?
     
     // MARK: - NSViewController
     
@@ -76,6 +79,13 @@ class ShareExtensionController: NSViewController {
         } else {
             logger.debug("No Attachments")
         }
+        
+        // Refresh TouchBar scrubber when device statuses change
+        touchBarStatusCancellable = viewModel.$deviceStatuses
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.touchBarScrubber?.reloadData()
+            }
         
         // Register for reverse Darwin notifications from main app (transfer status updates)
         let statusNotificationName = "com.soduto.share.status" as CFString

--- a/Soduto Share/Controllers/ShareExtensionController.swift
+++ b/Soduto Share/Controllers/ShareExtensionController.swift
@@ -73,7 +73,7 @@ class ShareExtensionController: NSViewController {
         }
         
         // Register for reverse Darwin notifications from main app (transfer status updates)
-        let statusNotificationName = "com.Soduto.Share.Status" as CFString
+        let statusNotificationName = "com.soduto.share.status" as CFString
         CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), Unmanaged.passUnretained(self).toOpaque(), { _, observer, _, _, _ in
             guard let observer = observer else { return }
             let controller = Unmanaged<ShareExtensionController>.fromOpaque(observer).takeUnretainedValue()
@@ -252,7 +252,7 @@ class ShareExtensionController: NSViewController {
     // MARK: - Private Helpers
     
     private func notifyMainApp() {
-        let notificationName = CFNotificationName("com.Soduto.Share" as CFString)
+        let notificationName = CFNotificationName("com.soduto.share.handoff" as CFString)
         let notificationCenter = CFNotificationCenterGetDarwinNotifyCenter()
         CFNotificationCenterPostNotification(notificationCenter, notificationName, nil, nil, false)
     }

--- a/Soduto Share/Info.plist
+++ b/Soduto Share/Info.plist
@@ -9,7 +9,7 @@
             <key>NSExtensionAttributes</key>
             <dict>
                 <key>NSExtensionActivationRule</key>
-                <string>SUBQUERY(extensionItems, $item, SUBQUERY($item.attachments, $att, ((ANY $att.registeredTypeIdentifiers UTI-CONFORMS-TO "public.data" AND NOT ANY $att.registeredTypeIdentifiers UTI-CONFORMS-TO "public.folder" AND NOT ANY $att.registeredTypeIdentifiers UTI-CONFORMS-TO "com.apple.package") OR ANY $att.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url" OR ANY $att.registeredTypeIdentifiers UTI-CONFORMS-TO "public.text")).@count >= 1).@count >= 1</string>
+                <string>SUBQUERY(extensionItems, $item, SUBQUERY($item.attachments, $att, (ANY $att.registeredTypeIdentifiers UTI-CONFORMS-TO "public.data" OR ANY $att.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url" OR ANY $att.registeredTypeIdentifiers UTI-CONFORMS-TO "public.text") AND NOT ANY $att.registeredTypeIdentifiers UTI-CONFORMS-TO "public.directory" AND NOT ANY $att.registeredTypeIdentifiers UTI-CONFORMS-TO "com.apple.package" AND NOT ANY $att.registeredTypeIdentifiers UTI-CONFORMS-TO "public.symlink" AND NOT ANY $att.registeredTypeIdentifiers UTI-CONFORMS-TO "public.volume" AND NOT ANY $att.registeredTypeIdentifiers UTI-CONFORMS-TO "public.folder").@count >= 1).@count >= 1</string>
             </dict>
             <key>NSExtensionPointIdentifier</key>
             <string>com.apple.share-services</string>

--- a/Soduto Share/Views/DeviceScrubberItemView.swift
+++ b/Soduto Share/Views/DeviceScrubberItemView.swift
@@ -12,6 +12,10 @@ class DeviceScrubberItemView: NSScrubberItemView {
     private let iconView = NSImageView()
     private let nameLabel = NSTextField(labelWithString: "")
     
+    var isDisabledVisually: Bool = false {
+        didSet { updateAppearance() }
+    }
+    
     override var isSelected: Bool {
         didSet { updateAppearance() }
     }
@@ -21,12 +25,18 @@ class DeviceScrubberItemView: NSScrubberItemView {
     }
     
     private func updateAppearance() {
-        if isHighlighted {
+        if isDisabledVisually {
+            layer?.backgroundColor = NSColor.white.withAlphaComponent(0.08).cgColor
+            alphaValue = 0.4
+        } else if isHighlighted {
             layer?.backgroundColor = NSColor.white.withAlphaComponent(0.35).cgColor
+            alphaValue = 1.0
         } else if isSelected {
             layer?.backgroundColor = NSColor.white.withAlphaComponent(0.25).cgColor
+            alphaValue = 1.0
         } else {
             layer?.backgroundColor = NSColor.white.withAlphaComponent(0.15).cgColor
+            alphaValue = 1.0
         }
     }
     

--- a/Soduto Share/Views/ShareSheetView.swift
+++ b/Soduto Share/Views/ShareSheetView.swift
@@ -8,6 +8,44 @@
 
 import SwiftUI
 
+// MARK: - Transfer Status
+
+enum DeviceTransferStatus: Equatable {
+    case idle         // no decoration, interactive
+    case transferring // breathing ring, disabled
+    case sent         // green ring (after brief green overlay flash), disabled
+    case failed       // red ring (after brief red overlay flash), interactive (retry)
+}
+
+// MARK: - View Model
+
+class ShareViewModel: ObservableObject {
+    @Published var deviceStatuses: [DeviceTransferStatus]
+    @Published var cachedBookmarks: [Data]? = nil
+    @Published var cachedTexts: [String]? = nil
+    @Published var isCollectingAttachments: Bool = false
+    
+    init(deviceCount: Int) {
+        deviceStatuses = Array(repeating: .idle, count: deviceCount)
+    }
+    
+    /// True once any device has been tapped (regardless of outcome).
+    var hasInitiatedAnyShare: Bool {
+        deviceStatuses.contains(where: { $0 != .idle })
+    }
+    
+    /// Whether a device is currently interactive (can be tapped).
+    func isInteractive(_ index: Int) -> Bool {
+        guard index < deviceStatuses.count else { return false }
+        switch deviceStatuses[index] {
+        case .idle, .failed: return true
+        case .transferring, .sent: return false
+        }
+    }
+}
+
+// MARK: - Helpers
+
 /// Maps a device type string to the corresponding SF Symbol name.
 func sfSymbolName(for deviceType: String) -> String {
     switch deviceType {
@@ -19,10 +57,13 @@ func sfSymbolName(for deviceType: String) -> String {
     }
 }
 
+// MARK: - ShareSheetView
+
 struct ShareSheetView: View {
+    @ObservedObject var viewModel: ShareViewModel
     let deviceEntries: [[String: String]]
     let onDeviceSelected: (Int) -> Void
-    let onCancel: () -> Void
+    let onDismiss: () -> Void
     
     private let columns = [GridItem(.adaptive(minimum: 80))]
     
@@ -57,7 +98,8 @@ struct ShareSheetView: View {
                         ForEach(Array(deviceEntries.enumerated()), id: \.offset) { index, entry in
                             DeviceBubble(
                                 name: entry["name"] ?? "Unknown Device",
-                                type: entry["type"] ?? "unknown"
+                                type: entry["type"] ?? "unknown",
+                                status: viewModel.deviceStatuses[index]
                             ) {
                                 onDeviceSelected(index)
                             }
@@ -72,10 +114,17 @@ struct ShareSheetView: View {
             // Footer
             HStack {
                 Spacer()
-                Button("Cancel") {
-                    onCancel()
+                if viewModel.hasInitiatedAnyShare {
+                    Button("Done") {
+                        onDismiss()
+                    }
+                    .keyboardShortcut(.defaultAction)
+                } else {
+                    Button("Cancel") {
+                        onDismiss()
+                    }
+                    .keyboardShortcut(.cancelAction)
                 }
-                .keyboardShortcut(.cancelAction)
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 8)
@@ -84,27 +133,85 @@ struct ShareSheetView: View {
     }
 }
 
+// MARK: - DeviceBubble
+
 struct DeviceBubble: View {
     let name: String
     let type: String
+    let status: DeviceTransferStatus
     let action: () -> Void
     
     @State private var isHovering = false
+    @State private var ringBreathing = false
+    @State private var showFlashOverlay = false
+    
+    private var isInteractive: Bool {
+        status == .idle || status == .failed
+    }
+    
+    private var ringColor: Color {
+        switch status {
+        case .idle:         return .clear
+        case .transferring: return .accentColor
+        case .sent:         return .green
+        case .failed:       return .red
+        }
+    }
+    
+    private var statusTooltip: String {
+        switch status {
+        case .idle:         return name
+        case .transferring: return "\(name) — Sending\u{2026}"
+        case .sent:         return "\(name) — Sent"
+        case .failed:       return "\(name) — Failed"
+        }
+    }
     
     var body: some View {
         Button(action: action) {
             VStack(spacing: 6) {
                 ZStack {
+                    // Ring (hidden when idle)
+                    if status != .idle {
+                        Circle()
+                            .stroke(ringColor, lineWidth: 2.5)
+                            .frame(width: 59, height: 59)
+                            .opacity(status == .transferring ? (ringBreathing ? 0.3 : 1.0) : 1.0)
+                    }
+                    
+                    // Background circle
                     Circle()
-                        .fill(isHovering
+                        .fill(isHovering && isInteractive
                               ? Color.accentColor.opacity(0.15)
                               : Color(NSColor.controlBackgroundColor))
                         .frame(width: 56, height: 56)
                     
+                    // Device icon
                     Image(systemName: sfSymbolName(for: type))
                         .font(.system(size: 24))
                         .foregroundColor(.primary)
+                    
+                    // Flash overlay (momentary, on status transition)
+                    if showFlashOverlay {
+                        if status == .sent {
+                            Circle()
+                                .fill(Color.green.opacity(0.85))
+                                .frame(width: 56, height: 56)
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 22, weight: .bold))
+                                .foregroundColor(.white)
+                        } else if status == .failed {
+                            Circle()
+                                .fill(Color.red.opacity(0.85))
+                                .frame(width: 56, height: 56)
+                            Image(systemName: "xmark")
+                                .font(.system(size: 22, weight: .bold))
+                                .foregroundColor(.white)
+                        }
+                    }
                 }
+                .animation(.easeInOut(duration: 0.25), value: status)
+                .animation(.easeInOut(duration: 0.3), value: showFlashOverlay)
                 
                 Text(name)
                     .font(.system(size: 11))
@@ -114,9 +221,34 @@ struct DeviceBubble: View {
             }
         }
         .buttonStyle(.plain)
-        .help(name)
+        .disabled(!isInteractive)
+        .help(statusTooltip)
         .onHover { hovering in
             isHovering = hovering
+        }
+        .onChange(of: status) { newStatus in
+            switch newStatus {
+            case .transferring:
+                showFlashOverlay = false
+                withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
+                    ringBreathing = true
+                }
+            case .sent, .failed:
+                withAnimation(.default) {
+                    ringBreathing = false
+                }
+                withAnimation(.easeIn(duration: 0.2)) {
+                    showFlashOverlay = true
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                    withAnimation(.easeOut(duration: 0.5)) {
+                        showFlashOverlay = false
+                    }
+                }
+            case .idle:
+                ringBreathing = false
+                showFlashOverlay = false
+            }
         }
     }
 }
@@ -124,6 +256,7 @@ struct DeviceBubble: View {
 
 #Preview {
     ShareSheetView(
+        viewModel: ShareViewModel(deviceCount: 5),
         deviceEntries: [
             ["id": "pixel-9", "name": "Pixel 9", "type": "phone"],
             ["id": "galaxy-tab", "name": "Galaxy Tab", "type": "tablet"],
@@ -132,6 +265,6 @@ struct DeviceBubble: View {
             ["id": "unknowndevice", "name": "Unknown Device", "type": "unknowndevice"]
         ],
         onDeviceSelected: { _ in },
-        onCancel: { }
+        onDismiss: { }
     )
 }

--- a/Soduto/AppDelegate.swift
+++ b/Soduto/AppDelegate.swift
@@ -193,22 +193,19 @@ class AppDelegate: NSObject, NSApplicationDelegate, DeviceManagerDelegate {
         let texts = AppDefaultsStore.ShareExtension.sharedTexts ?? []
         
         guard !bookmarks.isEmpty || !texts.isEmpty else {
-            updateTransferStatus(deviceId: deviceId, status: "failed")
-            notifyExtensionOfStatus()
+            ShareService.reportExtensionTransferStatus(deviceId: deviceId, status: "failed")
             UserNotificationHelper.show(title: "Soduto Share", body: "Nothing to share. Please try again.", sound: true, id: "NoShareData")
             return
         }
         
         guard let shareService = self.serviceManager.service(ofType: ShareService.self) else {
-            updateTransferStatus(deviceId: deviceId, status: "failed")
-            notifyExtensionOfStatus()
+            ShareService.reportExtensionTransferStatus(deviceId: deviceId, status: "failed")
             UserNotificationHelper.show(title: "Soduto Share", body: "Share service is not available. Please restart Soduto.", sound: true, id: "ShareServiceUnavailable")
             return
         }
         
         guard let device = self.deviceManager.device(withId: deviceId) else {
-            updateTransferStatus(deviceId: deviceId, status: "failed")
-            notifyExtensionOfStatus()
+            ShareService.reportExtensionTransferStatus(deviceId: deviceId, status: "failed")
             UserNotificationHelper.show(title: "Soduto Share", body: "The selected device is no longer reachable.", sound: true, id: "DeviceUnreachable")
             return
         }
@@ -251,28 +248,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, DeviceManagerDelegate {
             // Don't report status yet — ShareService will when uploads actually complete
         } else if failedCount == bookmarks.count && !bookmarks.isEmpty && texts.isEmpty {
             // Everything failed, nothing was sent
-            updateTransferStatus(deviceId: deviceId, status: "failed")
-            notifyExtensionOfStatus()
+            ShareService.reportExtensionTransferStatus(deviceId: deviceId, status: "failed")
         } else {
             // Only URLs/texts were shared (no file payloads) — they complete immediately
-            updateTransferStatus(deviceId: deviceId, status: "success")
-            notifyExtensionOfStatus()
+            ShareService.reportExtensionTransferStatus(deviceId: deviceId, status: "success")
         }
         
         // Clear consumed data (NOT transferStatuses — extension needs them)
+        // Each device reads only its own transferStatus entry by ID. Old entries are inert and cleared on extension deinit
         AppDefaultsStore.ShareExtension.fileBookmarkData = nil
         AppDefaultsStore.ShareExtension.sharedTexts = nil
         AppDefaultsStore.ShareExtension.selectedDevice = nil
-    }
-    
-    private func updateTransferStatus(deviceId: String, status: String) {
-        var statuses = AppDefaultsStore.ShareExtension.transferStatuses ?? [:]
-        statuses[deviceId] = status
-        AppDefaultsStore.ShareExtension.transferStatuses = statuses
-    }
-    
-    private func notifyExtensionOfStatus() {
-        let name = CFNotificationName("com.soduto.share.status" as CFString)
-        CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), name, nil, nil, false)
     }
 }

--- a/Soduto/AppDelegate.swift
+++ b/Soduto/AppDelegate.swift
@@ -220,13 +220,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, DeviceManagerDelegate {
             do {
                 var isStale = false
                 let url = try URL(resolvingBookmarkData: data, options: .withoutUI, relativeTo: nil, bookmarkDataIsStale: &isStale)
-                if shareService.shareFromExtension(url: url, to: device) {
-                    fileUploadCount += 1
+                switch shareService.shareFromExtension(url: url, to: device) {
+                case .fileUploadQueued:    fileUploadCount += 1
+                case .sentWithoutPayload:  break
+                case .skipped:             failedCount += 1
                 }
             } catch {
                 failedCount += 1
                 Log.error?.message("Failed to resolve bookmark: \(error)")
             }
+        }
+        
+        if failedCount > 0 {
+            let message = failedCount == bookmarks.count
+            ? "Soduto Share doesn't have permissions to read files in this directory. Drag the file to the menu bar icon to share!"
+            : "\(failedCount) of \(bookmarks.count) items could not be shared."
+            UserNotificationHelper.show(title: "Soduto Share", subtitle: "Oops! We got lost!", body: message, sound: true, id: "FileAccessDenied")
         }
         
         // Process shared texts
@@ -242,10 +251,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, DeviceManagerDelegate {
             // Don't report status yet — ShareService will when uploads actually complete
         } else if failedCount == bookmarks.count && !bookmarks.isEmpty && texts.isEmpty {
             // Everything failed, nothing was sent
-            let message = failedCount == bookmarks.count
-            ? "Soduto Share doesn't have permissions to read files in this directory. Drag the file to the menu bar icon to share!"
-            : "\(failedCount) of \(bookmarks.count) files could not be shared due to permission issues."
-            UserNotificationHelper.show(title: "Soduto Share", subtitle: "Oops! We got lost!", body: message, sound: true, id: "FileAccessDenied")
             updateTransferStatus(deviceId: deviceId, status: "failed")
             notifyExtensionOfStatus()
         } else {

--- a/Soduto/AppDelegate.swift
+++ b/Soduto/AppDelegate.swift
@@ -262,6 +262,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, DeviceManagerDelegate {
         // Clear consumed data (NOT transferStatuses — extension needs them)
         AppDefaultsStore.ShareExtension.fileBookmarkData = nil
         AppDefaultsStore.ShareExtension.sharedTexts = nil
+        AppDefaultsStore.ShareExtension.selectedDevice = nil
     }
     
     private func updateTransferStatus(deviceId: String, status: String) {

--- a/Soduto/AppDelegate.swift
+++ b/Soduto/AppDelegate.swift
@@ -83,7 +83,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, DeviceManagerDelegate {
         self.serviceManager.add(service: MPRISService())
         
         self.updateValidDevices()
-        let notificationName = "com.Soduto.Share" as CFString
+        let notificationName = "com.soduto.share.handoff" as CFString
         let notificationCenter = CFNotificationCenterGetDarwinNotifyCenter()
         registerShareExtensionObserver(notificationCenter, notificationName)
         

--- a/Soduto/AppDelegate.swift
+++ b/Soduto/AppDelegate.swift
@@ -27,6 +27,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, DeviceManagerDelegate {
     let serviceManager = ServiceManager()
     private(set) var userNotificationManager: UserNotificationManager!
     let updaterController: SPUStandardUpdaterController
+    private var heartbeatTimer: Timer?
     
     static let logLevelConfigurationKey = "com.soduto.logLevel"
     
@@ -83,6 +84,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, DeviceManagerDelegate {
         self.serviceManager.add(service: MPRISService())
         
         self.updateValidDevices()
+        self.startHeartbeat()
         let notificationName = "com.soduto.share.handoff" as CFString
         let notificationCenter = CFNotificationCenterGetDarwinNotifyCenter()
         registerShareExtensionObserver(notificationCenter, notificationName)
@@ -95,7 +97,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, DeviceManagerDelegate {
     }
     
     func applicationWillTerminate(_ aNotification: Notification) {
-        // Insert code here to tear down your application
+        heartbeatTimer?.invalidate()
+        AppDefaultsStore.ShareExtension.appLastHeartbeat = 0
+        AppDefaultsStore.ShareExtension.reachableDevices = []
     }
     
     
@@ -149,6 +153,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, DeviceManagerDelegate {
     }
     
     // MARK: Extension Support
+    
+    private func startHeartbeat() {
+        AppDefaultsStore.ShareExtension.appLastHeartbeat = Date().timeIntervalSince1970
+        heartbeatTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { _ in
+            AppDefaultsStore.ShareExtension.appLastHeartbeat = Date().timeIntervalSince1970
+        }
+    }
     
     public func updateValidDevices() {
         self.validDevices = deviceManager.pairedRechableDevices

--- a/Soduto/AppDelegate.swift
+++ b/Soduto/AppDelegate.swift
@@ -182,38 +182,40 @@ class AppDelegate: NSObject, NSApplicationDelegate, DeviceManagerDelegate {
         let texts = AppDefaultsStore.ShareExtension.sharedTexts ?? []
         
         guard !bookmarks.isEmpty || !texts.isEmpty else {
+            updateTransferStatus(deviceId: deviceId, status: "failed")
+            notifyExtensionOfStatus()
             UserNotificationHelper.show(title: "Soduto Share", body: "Nothing to share. Please try again.", sound: true, id: "NoShareData")
             return
         }
         
         guard let shareService = self.serviceManager.service(ofType: ShareService.self) else {
+            updateTransferStatus(deviceId: deviceId, status: "failed")
+            notifyExtensionOfStatus()
             UserNotificationHelper.show(title: "Soduto Share", body: "Share service is not available. Please restart Soduto.", sound: true, id: "ShareServiceUnavailable")
             return
         }
         
         guard let device = self.deviceManager.device(withId: deviceId) else {
+            updateTransferStatus(deviceId: deviceId, status: "failed")
+            notifyExtensionOfStatus()
             UserNotificationHelper.show(title: "Soduto Share", body: "The selected device is no longer reachable.", sound: true, id: "DeviceUnreachable")
             return
         }
         
         // Process file/URL bookmarks
         var failedCount = 0
+        var fileUploadCount = 0
         for data in bookmarks {
             do {
                 var isStale = false
                 let url = try URL(resolvingBookmarkData: data, options: .withoutUI, relativeTo: nil, bookmarkDataIsStale: &isStale)
-                shareService.shareFromExtension(url: url, to: device)
+                if shareService.shareFromExtension(url: url, to: device) {
+                    fileUploadCount += 1
+                }
             } catch {
                 failedCount += 1
                 Log.error?.message("Failed to resolve bookmark: \(error)")
             }
-        }
-        
-        if failedCount > 0 {
-            let message = failedCount == bookmarks.count
-            ? "Soduto Share doesn't have permissions to read files in this directory. Drag the file to the menu bar icon to share!"
-            : "\(failedCount) of \(bookmarks.count) files could not be shared due to permission issues."
-            UserNotificationHelper.show(title: "Soduto Share", subtitle: "Oops! We got lost!", body: message, sound: true, id: "FileAccessDenied")
         }
         
         // Process shared texts
@@ -221,8 +223,39 @@ class AppDelegate: NSObject, NSApplicationDelegate, DeviceManagerDelegate {
             shareService.shareFromExtension(text: text, to: device)
         }
         
-        // Clear consumed data
+        /// Report transfer status back to the extension.
+        /// File uploads (with payloads) are tracked by ShareService — it reports the real completion status via Darwin notification when all uploads finish.
+        /// Non-file transfers (URLs, text) complete immediately.
+        if fileUploadCount > 0 {
+            shareService.beginTrackingExtensionUploads(deviceId: deviceId, fileCount: fileUploadCount)
+            // Don't report status yet — ShareService will when uploads actually complete
+        } else if failedCount == bookmarks.count && !bookmarks.isEmpty && texts.isEmpty {
+            // Everything failed, nothing was sent
+            let message = failedCount == bookmarks.count
+            ? "Soduto Share doesn't have permissions to read files in this directory. Drag the file to the menu bar icon to share!"
+            : "\(failedCount) of \(bookmarks.count) files could not be shared due to permission issues."
+            UserNotificationHelper.show(title: "Soduto Share", subtitle: "Oops! We got lost!", body: message, sound: true, id: "FileAccessDenied")
+            updateTransferStatus(deviceId: deviceId, status: "failed")
+            notifyExtensionOfStatus()
+        } else {
+            // Only URLs/texts were shared (no file payloads) — they complete immediately
+            updateTransferStatus(deviceId: deviceId, status: "success")
+            notifyExtensionOfStatus()
+        }
+        
+        // Clear consumed data (NOT transferStatuses — extension needs them)
         AppDefaultsStore.ShareExtension.fileBookmarkData = nil
         AppDefaultsStore.ShareExtension.sharedTexts = nil
+    }
+    
+    private func updateTransferStatus(deviceId: String, status: String) {
+        var statuses = AppDefaultsStore.ShareExtension.transferStatuses ?? [:]
+        statuses[deviceId] = status
+        AppDefaultsStore.ShareExtension.transferStatuses = statuses
+    }
+    
+    private func notifyExtensionOfStatus() {
+        let name = CFNotificationName("com.soduto.share.status" as CFString)
+        CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), name, nil, nil, false)
     }
 }

--- a/Soduto/Services/ShareService.swift
+++ b/Soduto/Services/ShareService.swift
@@ -230,7 +230,7 @@ public class ShareService: NSObject, Service, DownloadTaskDelegate, ConnectionDe
         if tracking.succeeded + tracking.failed >= tracking.total {
             pendingExtensionUploads.removeValue(forKey: deviceId)
             let status = tracking.failed > 0 ? "failed" : "success"
-            reportExtensionTransferStatus(deviceId: deviceId, status: status)
+            Self.reportExtensionTransferStatus(deviceId: deviceId, status: status)
         } else {
             pendingExtensionUploads[deviceId] = tracking
         }
@@ -395,7 +395,7 @@ public class ShareService: NSObject, Service, DownloadTaskDelegate, ConnectionDe
     }
     
     /// Reports transfer status back to the Share Extension via App Group UserDefaults + Darwin notification.
-    private func reportExtensionTransferStatus(deviceId: String, status: String) {
+    public static func reportExtensionTransferStatus(deviceId: String, status: String) {
         var statuses = AppDefaultsStore.ShareExtension.transferStatuses ?? [:]
         statuses[deviceId] = status
         AppDefaultsStore.ShareExtension.transferStatuses = statuses

--- a/Soduto/Services/ShareService.swift
+++ b/Soduto/Services/ShareService.swift
@@ -39,6 +39,12 @@ public class ShareService: NSObject, Service, DownloadTaskDelegate, ConnectionDe
     
     // MARK: Types
     
+    public enum ExtensionShareResult {
+        case fileUploadQueued    // file with payload, tracked via ConnectionDelegate
+        case sentWithoutPayload  // URL shared, completes immediately
+        case skipped             // unshareable (directory, unreadable, etc.)
+    }
+    
     private enum ShareError: Error {
         case partFileRenameFailed
     }
@@ -349,22 +355,25 @@ public class ShareService: NSObject, Service, DownloadTaskDelegate, ConnectionDe
     // MARK: Share Extension methods
     
     /// Called by AppDelegate's upload observer when the Share extension signals a file or URL to share.
-    /// - Returns: `true` if a file upload (with payload) was queued; `false` for URL/text-only packets or errors.
     @discardableResult
-    public func shareFromExtension(url: URL, to device: Device) -> Bool {
+    public func shareFromExtension(url: URL, to device: Device) -> ExtensionShareResult {
         guard device.isReachable && device.pairingStatus == .Paired else {
             UserNotificationHelper.show(title: device.name, subtitle: "Outbound Transfer Failed", body: "\(device.name) is no longer reachable.", sound: true, id: "DeviceUnreachableUpload", urgency: .timeSensitive)
-            return false
+            return .skipped
         }
         
         if let dataPacket = self.dataPacket(forFileUrl: url) {
             device.send(dataPacket)
             self.showUploadStartNotification(to: device)
-            return true
+            return .fileUploadQueued
+        } else if url.isFileURL {
+            // Directory, unreadable file, etc. — nothing to send
+            Log.error?.message("Cannot share file URL (unsupported content type): \(url)")
+            return .skipped
         } else {
             let dataPacket = self.dataPacket(forUrl: url)
             device.send(dataPacket)
-            return false
+            return .sentWithoutPayload
         }
     }
     

--- a/Soduto/Services/ShareService.swift
+++ b/Soduto/Services/ShareService.swift
@@ -101,6 +101,10 @@ public class ShareService: NSObject, Service, DownloadTaskDelegate, ConnectionDe
     private var devices: [Device.Id:Device] = [:]
     private var validDevices: [Device] { return self.devices.values.filter { $0.isReachable && $0.pairingStatus == .Paired } }
     
+    /// Tracks pending file uploads initiated by the Share Extension, per device.
+    /// When all tracked uploads for a device complete, the final status is reported back to the extension.
+    private var pendingExtensionUploads: [Device.Id: (total: Int, succeeded: Int, failed: Int)] = [:]
+    
     
     // MARK: Service methods
     
@@ -207,6 +211,23 @@ public class ShareService: NSObject, Service, DownloadTaskDelegate, ConnectionDe
         guard packet.hasPayload(), packet.type == DataPacket.sharePacketType else { return }
         
         self.showUploadFinishNotification(connection: connection, succeeded: uploadedPayload)
+        
+        // Track extension-initiated uploads and report final status when all complete
+        guard let deviceId = try? connection.identity?.getDeviceId(), var tracking = pendingExtensionUploads[deviceId] else { return }
+        
+        if uploadedPayload {
+            tracking.succeeded += 1
+        } else {
+            tracking.failed += 1
+        }
+        
+        if tracking.succeeded + tracking.failed >= tracking.total {
+            pendingExtensionUploads.removeValue(forKey: deviceId)
+            let status = tracking.failed > 0 ? "failed" : "success"
+            reportExtensionTransferStatus(deviceId: deviceId, status: status)
+        } else {
+            pendingExtensionUploads[deviceId] = tracking
+        }
     }
     
     
@@ -328,18 +349,22 @@ public class ShareService: NSObject, Service, DownloadTaskDelegate, ConnectionDe
     // MARK: Share Extension methods
     
     /// Called by AppDelegate's upload observer when the Share extension signals a file or URL to share.
-    public func shareFromExtension(url: URL, to device: Device) {
+    /// - Returns: `true` if a file upload (with payload) was queued; `false` for URL/text-only packets or errors.
+    @discardableResult
+    public func shareFromExtension(url: URL, to device: Device) -> Bool {
         guard device.isReachable && device.pairingStatus == .Paired else {
             UserNotificationHelper.show(title: device.name, subtitle: "Outbound Transfer Failed", body: "\(device.name) is no longer reachable.", sound: true, id: "DeviceUnreachableUpload", urgency: .timeSensitive)
-            return
+            return false
         }
         
         if let dataPacket = self.dataPacket(forFileUrl: url) {
             device.send(dataPacket)
             self.showUploadStartNotification(to: device)
+            return true
         } else {
             let dataPacket = self.dataPacket(forUrl: url)
             device.send(dataPacket)
+            return false
         }
     }
     
@@ -351,6 +376,23 @@ public class ShareService: NSObject, Service, DownloadTaskDelegate, ConnectionDe
         }
         let dataPacket = self.dataPacket(forText: text)
         device.send(dataPacket)
+    }
+    
+    /// Begin tracking file uploads initiated by the Share Extension.
+    /// When all tracked uploads for this device complete, the final status is reported back to the extension, via the `com.soduto.share.status` Darwin notification.
+    public func beginTrackingExtensionUploads(deviceId: String, fileCount: Int) {
+        guard fileCount > 0 else { return }
+        pendingExtensionUploads[deviceId] = (total: fileCount, succeeded: 0, failed: 0)
+    }
+    
+    /// Reports transfer status back to the Share Extension via App Group UserDefaults + Darwin notification.
+    private func reportExtensionTransferStatus(deviceId: String, status: String) {
+        var statuses = AppDefaultsStore.ShareExtension.transferStatuses ?? [:]
+        statuses[deviceId] = status
+        AppDefaultsStore.ShareExtension.transferStatuses = statuses
+        
+        let name = CFNotificationName("com.soduto.share.status" as CFString)
+        CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), name, nil, nil, false)
     }
     
     


### PR DESCRIPTION
# Summary
This pull request implements a major UX improvement for the share extension, providing real-time visual feedback for file transfer status per device and preventing duplicate or invalid share attempts. It introduces a new `ShareViewModel` for state management, adds transfer status indicators to the UI, and refactors the communication between the extension and the main app for reliability and clarity.

## Key changes

### Transfer Status Tracking and Communication
- Added a `transferStatuses` dictionary to `AppDefaultsStore.ShareExtension` to persist and share transfer status (success/failed) for each device between the share extension and the main app.
- The share extension now registers for Darwin notifications to receive status updates from the main app and updates the UI accordingly.
- Notification names between extension and main app are now consistent, using `com.soduto.share.handoff` and `com.soduto.share.status`.

### UI/UX Improvements: Visual Feedback and Interaction
- Introduced `DeviceTransferStatus` and a new `ShareViewModel` to track the transfer state of each device and manage attachment caching and interactivity.
- Refactored `ShareSheetView` and `DeviceBubble` to visually indicate status: idle, transferring (breathing ring), sent (green ring/flash), and failed (red ring/flash). Devices are only interactive when appropriate.
- The footer button now shows "Done" after a share is initiated, and disables cancellation during transfer.

### Share Logic and State Management
- Prevents duplicate or invalid share attempts by checking device interactivity and attachment collection state before starting a transfer.
- Caches attachments and text on first share, allowing subsequent device shares without re-collecting data.
- Refactored handoff logic to clear and update transfer statuses and only notify the main app when there is data to share.
- Added a `appLastHeartbeat` timestamp to `AppDefaultsStore.ShareExtension` for robust extension–main app communication, including crash/stale detection. The extension would not display any devices, if the main app is not running.

### Codebase and API Consistency
- Updated notification and touch bar item identifiers to use consistent lowercase naming.
- Refactored the share extension controller to use `onDismiss` instead of `onCancel` for sheet closure, unifying the handling of "Done" and "Cancel" actions.
- Updated the activation rule in `Info.plist` to exclude more non-shareable file types (directories, symlinks, volumes, folders, packages), improving reliability and preventing errors.

These changes collectively make the share experience much more robust and user-friendly, with clear feedback for each device, safe handling of transfers, supporting retries, and handling edge cases such as app crashes and stale data.