### PR TITLE
chore(deps): remove reachability.swift and migrate to nwpathmonitor

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,4 @@
 github "sannidhyaroy/CleanroomLogger" "master"
 github "sannidhyaroy/CocoaAsyncSocket" "master"
 github "sannidhyaroy/NMSSH" "soduto"
-github "sannidhyaroy/Reachability.swift" "master"
 binary "https://sparkle-project.org/Carthage/Sparkle.json"

--- a/Soduto.xcodeproj/project.pbxproj
+++ b/Soduto.xcodeproj/project.pbxproj
@@ -49,7 +49,6 @@
 		761FBEF3293211C50034FD44 /* NMSSH.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 76B5805D2930EF31003453FD /* NMSSH.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		761FBEF4293212030034FD44 /* CleanroomLogger.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 76B5805B2930EF31003453FD /* CleanroomLogger.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		761FBEF5293212580034FD44 /* CocoaAsyncSocket.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 76B5805C2930EF31003453FD /* CocoaAsyncSocket.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		761FBEF6293212600034FD44 /* Reachability.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 76B5805E2930EF31003453FD /* Reachability.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		761FBEF7293212E10034FD44 /* CleanroomLogger.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 76B5805B2930EF31003453FD /* CleanroomLogger.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		76A5B0D029320D230061BF0B /* NMSSH.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 76B5805D2930EF31003453FD /* NMSSH.xcframework */; settings = {ATTRIBUTES = (Required, ); }; };
 		76B580582930EE1B003453FD /* libcrypto.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 76B580552930EE1B003453FD /* libcrypto.a */; };
@@ -235,7 +234,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				761FBEF7293212E10034FD44 /* CleanroomLogger.xcframework in Embed Frameworks */,
-				761FBEF6293212600034FD44 /* Reachability.xcframework in Embed Frameworks */,
 				761FBEF5293212580034FD44 /* CocoaAsyncSocket.xcframework in Embed Frameworks */,
 				31B189B829ED73A1001C8735 /* Sparkle.framework in Embed Frameworks */,
 			);
@@ -284,7 +282,6 @@
 		76B5805B2930EF31003453FD /* CleanroomLogger.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CleanroomLogger.xcframework; path = Carthage/Build/CleanroomLogger.xcframework; sourceTree = "<group>"; };
 		76B5805C2930EF31003453FD /* CocoaAsyncSocket.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CocoaAsyncSocket.xcframework; path = Carthage/Build/CocoaAsyncSocket.xcframework; sourceTree = "<group>"; };
 		76B5805D2930EF31003453FD /* NMSSH.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = NMSSH.xcframework; path = Carthage/Build/NMSSH.xcframework; sourceTree = "<group>"; };
-		76B5805E2930EF31003453FD /* Reachability.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Reachability.xcframework; path = Carthage/Build/Reachability.xcframework; sourceTree = "<group>"; };
 		8405381F1ED62282003798AA /* WelcomeWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeWindowController.swift; sourceTree = "<group>"; };
 		840FC2F81DEF6AF400AC4824 /* ClipboardService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClipboardService.swift; sourceTree = "<group>"; };
 		841E814C1D809C360096A846 /* Soduto.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Soduto.entitlements; sourceTree = "<group>"; };
@@ -784,7 +781,6 @@
 				76B5805B2930EF31003453FD /* CleanroomLogger.xcframework */,
 				76B5805C2930EF31003453FD /* CocoaAsyncSocket.xcframework */,
 				76B5805D2930EF31003453FD /* NMSSH.xcframework */,
-				76B5805E2930EF31003453FD /* Reachability.xcframework */,
 				76B580552930EE1B003453FD /* libcrypto.a */,
 				76B580572930EE1B003453FD /* libssh2.a */,
 				76B580562930EE1B003453FD /* libssl.a */,

--- a/Soduto/Acknowledgements.html
+++ b/Soduto/Acknowledgements.html
@@ -279,28 +279,6 @@ derivative of this code cannot be changed.  i.e. this code cannot simply be
 copied and put under another distribution licence
 [including the GNU Public Licence.]</p>
 
-<h1 id="reachabilityswift">Reachability.swift</h1>
-
-<p>Copyright (c) 2016 Ashley Mills</p>
-
-<p>Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the “Software”), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:</p>
-
-<p>The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.</p>
-
-<p>THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.</p>
-
 <h1 id="sparkle">Sparkle</h1>
 
 <p>Copyright (c) 2006-2013 Andy Matuschak.</p>

--- a/Soduto/Core/Connection.swift
+++ b/Soduto/Core/Connection.swift
@@ -9,7 +9,6 @@
 import Foundation
 import CocoaAsyncSocket
 import CleanroomLogger
-import Reachability
 
 public enum ConnectionError: Error {
     case InitializationAlreadyFinished
@@ -128,7 +127,7 @@ public class Connection: NSObject, GCDAsyncSocketDelegate, PairingHandlerDelegat
         self.socket = GCDAsyncSocket(delegate: nil, delegateQueue: DispatchQueue.main)
         self.sslCertificates = [ hostIdentity ]
         self.state = .Initializing
-
+        
         super.init()
         
         self.socket.delegate = self
@@ -213,7 +212,7 @@ public class Connection: NSObject, GCDAsyncSocketDelegate, PairingHandlerDelegat
     // MARK: Public API
     
     /// Try sending a packed with completion handler. Returns false if sending is declined because of capacity exceeded.
-    /// In such case the sender may try resending the packet when connection capacity changes. In other cases 
+    /// In such case the sender may try resending the packet when connection capacity changes. In other cases
     /// true is returned even if sending does not succeed - sending failure is reported through completion handler.
     public func send(_ dataPacket: DataPacket, whenCompleted: SendingCompletionHandler? = nil) -> Bool {
         if dataPacket.hasPayload() {
@@ -238,7 +237,7 @@ public class Connection: NSObject, GCDAsyncSocketDelegate, PairingHandlerDelegat
         self.readNextPacket()
     }
     
-    /// Discard and return unsent packets, so that they can be resent with other connection. This can be done only when 
+    /// Discard and return unsent packets, so that they can be resent with other connection. This can be done only when
     /// connection is already closed, otherwise behaviour is undefined
     public func reclaimUnsentPackets() -> [(dataPacket: DataPacket, completionHandler: SendingCompletionHandler?)] {
         assert(self.state == .Closed)
@@ -329,7 +328,7 @@ public class Connection: NSObject, GCDAsyncSocketDelegate, PairingHandlerDelegat
                 Log.error?.message("Could not deserialize received data packet")
             }
         }
-    
+        
         if self.packetsExpected != 0 {
             self.readNextPacket()
         }
@@ -345,7 +344,7 @@ public class Connection: NSObject, GCDAsyncSocketDelegate, PairingHandlerDelegat
     
     public func socketDidDisconnect(_ sock: GCDAsyncSocket, withError err: Error?) {
         Log.debug?.message("socketDidDisconnect(<\(sock)> withError:<\(String(describing: err))>)")
-    
+        
         // Execute state change before packets dicarding, so that delegate could reclaim unsent packets
         self.state = .Closed
         
@@ -430,7 +429,7 @@ public class Connection: NSObject, GCDAsyncSocketDelegate, PairingHandlerDelegat
         assert(self.state == .Open, "Connection expected to be open")
         self.pairingHandler!.updatePairingStatus(globalStatus: globalStatus)
     }
-
+    
     
     // MARK: CustomStringConvertible
     
@@ -601,10 +600,8 @@ public class Connection: NSObject, GCDAsyncSocketDelegate, PairingHandlerDelegat
                 strongSelf.delegate?.connectionCapacityChanged(strongSelf)
             }
         }
-        NotificationCenter.default.addObserver(forName: Notification.Name.reachabilityChanged, object: nil, queue: nil) { [weak self] notification in
-            if let reachability = notification.object as? Reachability, reachability.connection != .none {
-                self?.sendKeepAlivePacket()
-            }
+        NotificationCenter.default.addObserver(forName: ConnectionProvider.networkBecameReachableNotification, object: nil, queue: nil) { [weak self] _ in
+            self?.sendKeepAlivePacket()
         }
     }
     
@@ -638,5 +635,5 @@ public class Connection: NSObject, GCDAsyncSocketDelegate, PairingHandlerDelegat
             return DispatchQueue(label: label, qos: DispatchQoS.background)
         }
     }
-
+    
 }

--- a/Soduto/Core/ConnectionProvider.swift
+++ b/Soduto/Core/ConnectionProvider.swift
@@ -10,7 +10,7 @@ import Foundation
 import Cocoa
 import CocoaAsyncSocket
 import CleanroomLogger
-import Reachability
+import Network
 
 enum ConnectionProviderError: Error {
     case IdentityAbsent
@@ -29,11 +29,13 @@ public class ConnectionProvider: NSObject, GCDAsyncSocketDelegate, GCDAsyncUdpSo
     static public let minVersionWithSSLSupport: UInt = 6
     static public let minAnnouncementInterval: TimeInterval = 30.0
     static public let broadcastAnnouncementNotification: Notification.Name = Notification.Name(rawValue: "com.soduto.ConnectionProvider.broadcastAnnouncement")
+    static public let networkBecameReachableNotification: Notification.Name = Notification.Name(rawValue: "com.soduto.ConnectionProvider.networkBecameReachable")
     
     public weak var delegate: ConnectionProviderDelegate? = nil
     
     private let config: ConnectionConfiguration
-    private let reachability: Reachability? = Reachability()
+    private let pathMonitor: NWPathMonitor = NWPathMonitor()
+    private let pathMonitorQueue: DispatchQueue = DispatchQueue(label: "com.soduto.NetworkMonitor")
     private let udpSocket: GCDAsyncUdpSocket = GCDAsyncUdpSocket(delegate: nil, delegateQueue: DispatchQueue.main)
     private let tcpSocket: GCDAsyncSocket = GCDAsyncSocket(delegate: nil, delegateQueue: DispatchQueue.main)
     private var pendingConnections: Set<Connection> = Set<Connection>()
@@ -48,14 +50,16 @@ public class ConnectionProvider: NSObject, GCDAsyncSocketDelegate, GCDAsyncUdpSo
         
         super.init()
         
-        self.reachability?.whenReachable =  { [unowned self] _ in self.becameReachable() }
-        self.reachability?.whenUnreachable =  { [unowned self] _ in self.becameUnreachable() }
-        do {
-            try self.reachability?.startNotifier()
+        self.pathMonitor.pathUpdateHandler = { [weak self] path in
+            DispatchQueue.main.async {
+                if path.status == .satisfied {
+                    self?.becameReachable()
+                } else {
+                    self?.becameUnreachable()
+                }
+            }
         }
-        catch {
-            Log.error?.message("Failed to start monitoring network reachability: \(error)")
-        }
+        self.pathMonitor.start(queue: self.pathMonitorQueue)
         self.udpSocket.setDelegate(self)
         self.tcpSocket.delegate = self
         
@@ -63,6 +67,7 @@ public class ConnectionProvider: NSObject, GCDAsyncSocketDelegate, GCDAsyncUdpSo
     }
     
     deinit {
+        self.pathMonitor.cancel()
         NotificationCenter.default.removeObserver(self)
     }
     
@@ -292,6 +297,7 @@ public class ConnectionProvider: NSObject, GCDAsyncSocketDelegate, GCDAsyncUdpSo
     
     private func becameReachable() {
         Log.debug?.message("Became reachable")
+        NotificationCenter.default.post(name: ConnectionProvider.networkBecameReachableNotification, object: self)
         self.restart()
     }
     

--- a/Soduto/Core/ConnectionProvider.swift
+++ b/Soduto/Core/ConnectionProvider.swift
@@ -59,7 +59,6 @@ public class ConnectionProvider: NSObject, GCDAsyncSocketDelegate, GCDAsyncUdpSo
                 }
             }
         }
-        self.pathMonitor.start(queue: self.pathMonitorQueue)
         self.udpSocket.setDelegate(self)
         self.tcpSocket.delegate = self
         
@@ -101,6 +100,8 @@ public class ConnectionProvider: NSObject, GCDAsyncSocketDelegate, GCDAsyncUdpSo
         
         self.isStarted = true
         
+        // Start monitoring network reachability
+        self.pathMonitor.start(queue: self.pathMonitorQueue)
         broadcastAnnouncement()
         
         // Speculative broadcasts after some intervals.
@@ -112,6 +113,7 @@ public class ConnectionProvider: NSObject, GCDAsyncSocketDelegate, GCDAsyncUdpSo
     
     public func stop() {
         self.isStarted = false
+        self.pathMonitor.cancel()
         self.udpSocket.close()
         self.tcpSocket.disconnect()
     }


### PR DESCRIPTION
## Summary
This pull request removes the dependency on the [`Reachability.swift`](https://github.com/sannidhyaroy/Reachability.swift) library and replaces its usage with Apple's native `Network` framework for monitoring network reachability. The change streamlines the codebase by removing third-party code and updating all relevant logic and project references to use the new approach.

### Dependency removal and project cleanup
- Removed `Reachability.swift` from Xcode Build Frameworks for Target `Soduto`.
- Removed `Reachability.swift` from the `Cartfile` and all references to `Reachability.xcframework` from the Xcode Project, ensuring the project no longer depends on the library.
- Deleted the Reachability license section from `Soduto/Acknowledgements.html` as the library is no longer used.

### Code updates for network reachability
- Replaced all `Reachability` imports with the `Network` framework (`NWPathMonitor`) in `ConnectionProvider.swift` and updated initialization and monitoring logic accordingly.
- Updated the network reachability notification flow: introduced a new notification `ConnectionProvider.networkBecameReachableNotification` and refactored code in `Connection.swift` to use this notification instead of the previous `Reachability`-based notification.

These changes modernize network reachability handling and simplify project dependencies.