### PR TITLE
chore(deps): migrate `NMSSH` to `Citadel`

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,2 @@
 github "sannidhyaroy/CocoaAsyncSocket" "master"
-github "sannidhyaroy/NMSSH" "soduto"
 binary "https://sparkle-project.org/Carthage/Sparkle.json"

--- a/README.md
+++ b/README.md
@@ -78,29 +78,11 @@ Do note that currently there's no Homebrew formulae for my forked version and th
 >  *** Downloading binary-only framework Sparkle at "https://sparkle-project.org/Carthage/Sparkle.json"
 >  *** Skipped downloading CocoaAsyncSocket binary due to the error:
 >      "Bad credentials"
->  *** Skipped downloading NMSSH binary due to the error:
->      "Bad credentials"
->  *** Skipped downloading Reachability.swift binary due to the error:
->      "Bad credentials"
 >  ```
 >
 >  This is likely due to GitHub Rate Limits. You can create a [GitHub Token](https://github.com/settings/tokens) and export it as an environment variable (format: `ghp_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`):
 >  ```bash
 >  export GITHUB_ACCESS_TOKEN=<INSERT YOUR TOKEN HERE>
->  ```
-        
-
->  [!TIP]
->  If you get an error in Xcode that says:
->
->  `While building for macOS, no library for this platform was found in '/path/to/NMSSH.xcframework'.`
->
->  This means the NMSSH framework was built for iOS instead of macOS. To fix this, temporarily rename the Examples workspace and rebuild NMSSH:
->
->  ```bash
->  mv Carthage/Checkouts/NMSSH/Examples/Examples.xcworkspace Carthage/Checkouts/NMSSH/Examples/Examples.xcworkspace.bak
->  XCODE_XCCONFIG_FILE="./carthage.xcconfig" carthage build NMSSH --platform macOS --use-xcframeworks --no-use-binaries
->  mv Carthage/Checkouts/NMSSH/Examples/Examples.xcworkspace.bak Carthage/Checkouts/NMSSH/Examples/Examples.xcworkspace
 >  ```
 
 * Compile universal openssl and libssh2 library using [iSSH2](https://github.com/sannidhyaroy/iSSH2):

--- a/Soduto Files/AppDelegate.swift
+++ b/Soduto Files/AppDelegate.swift
@@ -11,23 +11,23 @@ import os
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate, BrowserWindowControllerDelegate {
-
+    
     // MARK: Types
-
+    
     struct MenuItemTags {
         // Application menu
         static let about: Int = 1
-
+        
         // Go menu
         static let back: Int = 1001
         static let forward: Int = 1002
         static let enclosingFolder: Int = 1003
-
+        
         // View menu
         static let toggleHiddenFiles: Int = 2001
         static let toggleThumbnails: Int = 2002
         static let foldersAlwaysFirst: Int = 2101
-
+        
         // File menu
         static let deleteFiles: Int = 3001
         static let newFolder: Int = 3002
@@ -37,16 +37,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, BrowserWindowControllerDeleg
         static let newTab: Int = 3006
         static let open: Int = 3007
     }
-
+    
     struct ToolbarItemTags {
         static let backForward: Int = 50001
     }
-
-
+    
+    
     // MARK: Properties
-
+    
     private(set) var browserWindowControllers: [BrowserWindowController] = []
-
+    
     var keyBrowserWindowController: BrowserWindowController? {
         return NSApp.keyWindow?.windowController as? BrowserWindowController
     }
@@ -185,7 +185,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, BrowserWindowControllerDeleg
     
     private func open(_ url: URL) {
         guard let scheme = url.scheme else { Logger.general.info("Input URL expected to contain valid scheme part."); return }
-
+        
         switch scheme {
         case "sftp":
             guard let host = url.host else { Logger.general.info("Input URL expected to contain valid host part."); return }
@@ -194,7 +194,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, BrowserWindowControllerDeleg
             let name = url.fragment ?? host
             let port: UInt16? = (url.port != nil) ? UInt16(url.port!) : nil
             let path = url.path
-
+            
             // Create SFTP file system asynchronously
             Task { @MainActor in
                 do {

--- a/Soduto Files/AppDelegate.swift
+++ b/Soduto Files/AppDelegate.swift
@@ -11,23 +11,23 @@ import os
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate, BrowserWindowControllerDelegate {
-    
+
     // MARK: Types
-    
+
     struct MenuItemTags {
         // Application menu
         static let about: Int = 1
-        
+
         // Go menu
         static let back: Int = 1001
         static let forward: Int = 1002
         static let enclosingFolder: Int = 1003
-        
+
         // View menu
         static let toggleHiddenFiles: Int = 2001
         static let toggleThumbnails: Int = 2002
         static let foldersAlwaysFirst: Int = 2101
-        
+
         // File menu
         static let deleteFiles: Int = 3001
         static let newFolder: Int = 3002
@@ -37,26 +37,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, BrowserWindowControllerDeleg
         static let newTab: Int = 3006
         static let open: Int = 3007
     }
-    
+
     struct ToolbarItemTags {
         static let backForward: Int = 50001
     }
-    
-    
+
+
     // MARK: Properties
-    
+
     private(set) var browserWindowControllers: [BrowserWindowController] = []
-    
+
     var keyBrowserWindowController: BrowserWindowController? {
         return NSApp.keyWindow?.windowController as? BrowserWindowController
-    }
-    
-    override init() {
-#if DEBUG
-        NMSSHLogger.shared().logLevel = .verbose
-#else
-        NMSSHLogger.shared().logLevel = .error
-#endif
     }
     
     
@@ -193,7 +185,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, BrowserWindowControllerDeleg
     
     private func open(_ url: URL) {
         guard let scheme = url.scheme else { Logger.general.info("Input URL expected to contain valid scheme part."); return }
-        
+
         switch scheme {
         case "sftp":
             guard let host = url.host else { Logger.general.info("Input URL expected to contain valid host part."); return }
@@ -202,13 +194,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, BrowserWindowControllerDeleg
             let name = url.fragment ?? host
             let port: UInt16? = (url.port != nil) ? UInt16(url.port!) : nil
             let path = url.path
-            guard let fs = try? SftpFileSystem(name: name, host: host, port: port, user: user, password: password, path: path) else {
-                var urlWithouPassword = URLComponents(url: url, resolvingAgainstBaseURL: false)
-                urlWithouPassword?.password = nil
-                Logger.general.info("Failed to connect to SFTP at URL [\(urlWithouPassword?.string ?? "", privacy: .public)]");
-                return
+
+            // Create SFTP file system asynchronously
+            Task { @MainActor in
+                do {
+                    let fs = try await SftpFileSystem(name: name, host: host, port: port, user: user, password: password, path: path)
+                    self.newBrowserWindow(with: fs)
+                } catch {
+                    var urlWithoutPassword = URLComponents(url: url, resolvingAgainstBaseURL: false)
+                    urlWithoutPassword?.password = nil
+                    Logger.general.error("Failed to connect to SFTP at URL [\(urlWithoutPassword?.string ?? "", privacy: .public)]: \(error.localizedDescription, privacy: .public)")
+                }
             }
-            newBrowserWindow(with: fs)
         default:
             Logger.general.info("Unsupported URL scheme: \(scheme, privacy: .public)")
         }

--- a/Soduto Files/SftpFileSystem.swift
+++ b/Soduto Files/SftpFileSystem.swift
@@ -10,13 +10,165 @@ import Foundation
 import os
 import Cocoa
 import UniformTypeIdentifiers
+import Citadel
+import NIOCore
 
-class SftpFileSystem: NSObject, FileSystem, NMSSHSessionDelegate {
-    private let thumbnailConcurrentOprationCount = 16
+// MARK: - Session Pool Actor
+
+/// An actor that manages a pool of SSH/SFTP connections for concurrent operations.
+/// Uses a semaphore-like pattern with async/await for thread-safe session management.
+private actor SftpSessionPool {
+    private let host: String
+    private let port: Int
+    private let user: String
+    private let password: String
+    private let poolSize: Int
+
+    private var sessions: [SFTPClient] = []
+    private var waiters: [CheckedContinuation<SFTPClient, Error>] = []
+    private var isShuttingDown = false
+
+    init(host: String, port: Int, user: String, password: String, poolSize: Int) async throws {
+        self.host = host
+        self.port = port
+        self.user = user
+        self.password = password
+        self.poolSize = poolSize
+
+        // Create initial sessions
+        for i in 0..<poolSize {
+            do {
+                let session = try await Self.createSession(host: host, port: port, user: user, password: password)
+                sessions.append(session)
+                Logger.filesystem.debug("Session pool: Created initial session \(i + 1, privacy: .public)/\(poolSize, privacy: .public)")
+            } catch {
+                Logger.filesystem.error("Session pool: Failed to create initial session \(i + 1, privacy: .public)/\(poolSize, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                // Continue with smaller pool
+            }
+        }
+
+        Logger.filesystem.debug("Session pool initialized with \(self.sessions.count, privacy: .public) sessions")
+    }
+
+    private static func createSession(host: String, port: Int, user: String, password: String) async throws -> SFTPClient {
+        let ssh = try await SSHClient.connect(
+            host: host,
+            port: port,
+            authenticationMethod: .passwordBased(username: user, password: password),
+            hostKeyValidator: .acceptAnything(),
+            reconnect: .never
+        )
+        return try await ssh.openSFTP()
+    }
+
+    /// Acquire a session from the pool. Suspends if none available.
+    func acquire() async throws -> SFTPClient {
+        if isShuttingDown {
+            throw SftpFileSystem.SftpError.connectionFailed
+        }
+
+        // If we have an available session, return it
+        if !sessions.isEmpty {
+            let session = sessions.removeFirst()
+            if session.isActive {
+                Logger.filesystem.debug("Session pool: Acquired session. Remaining: \(self.sessions.count, privacy: .public)")
+                return session
+            } else {
+                // Session died, try to get another or create new
+                Logger.filesystem.debug("Session pool: Found dead session, discarding")
+                return try await acquire()
+            }
+        }
+
+        // No sessions available, wait for one
+        return try await withCheckedThrowingContinuation { continuation in
+            waiters.append(continuation)
+            Logger.filesystem.debug("Session pool: No sessions available, waiting. Waiters: \(self.waiters.count, privacy: .public)")
+        }
+    }
+
+    /// Release a session back to the pool.
+    func release(_ session: SFTPClient) {
+        guard !isShuttingDown else {
+            Task { try? await session.close() }
+            return
+        }
+
+        // If there are waiters, give them the session directly
+        if !waiters.isEmpty {
+            let waiter = waiters.removeFirst()
+            if session.isActive {
+                waiter.resume(returning: session)
+                Logger.filesystem.debug("Session pool: Released session to waiter. Waiters remaining: \(self.waiters.count, privacy: .public)")
+            } else {
+                // Session is dead, create a new one for the waiter
+                Task {
+                    do {
+                        let newSession = try await Self.createSession(host: host, port: port, user: user, password: password)
+                        waiter.resume(returning: newSession)
+                    } catch {
+                        waiter.resume(throwing: error)
+                    }
+                }
+            }
+            return
+        }
+
+        // No waiters, return to pool if healthy
+        if session.isActive {
+            sessions.append(session)
+            Logger.filesystem.debug("Session pool: Released session. Pool size: \(self.sessions.count, privacy: .public)")
+        } else {
+            // Replace dead session
+            Logger.filesystem.debug("Session pool: Session dead, creating replacement")
+            Task {
+                do {
+                    let newSession = try await Self.createSession(host: host, port: port, user: user, password: password)
+                    await self.addSession(newSession)
+                } catch {
+                    Logger.filesystem.error("Session pool: Failed to create replacement session: \(error.localizedDescription, privacy: .public)")
+                }
+            }
+        }
+    }
+
+    private func addSession(_ session: SFTPClient) {
+        if !waiters.isEmpty {
+            let waiter = waiters.removeFirst()
+            waiter.resume(returning: session)
+        } else {
+            sessions.append(session)
+        }
+    }
+
+    /// Shutdown the pool and close all sessions.
+    func shutdown() async {
+        isShuttingDown = true
+
+        // Fail all waiters
+        for waiter in waiters {
+            waiter.resume(throwing: SftpFileSystem.SftpError.connectionFailed)
+        }
+        waiters.removeAll()
+
+        // Close all sessions
+        for session in sessions {
+            try? await session.close()
+        }
+        sessions.removeAll()
+
+        Logger.filesystem.debug("Session pool: Shutdown complete")
+    }
+}
+
+// MARK: - SftpFileSystem
+
+class SftpFileSystem: NSObject, FileSystem {
+    private let thumbnailConcurrentOperationCount = 16
     private let thumbnailSessionPoolSize = 6
-    
+
     // MARK: Types
-    
+
     enum SftpError: Error {
         case connectionFailed
         case authenticationFailed
@@ -32,611 +184,606 @@ class SftpFileSystem: NSObject, FileSystem, NMSSHSessionDelegate {
         case creatingDirectoryFailed(at: URL)
         case openInputStreamFailed(at: URL)
         case openOutputStreamFailed(at: URL)
+        case operationCancelled
     }
-    
-    typealias DownloadProgress = ((UInt, UInt)->Bool)
-    typealias UploadProgress = ((UInt)->Bool)
-    
-    
+
     // MARK: Properties
-    
+
     weak var delegate: FileSystemDelegate?
-    
+
     let name: String
     let rootUrl: URL
     let places: [Place] = []
-    
+
     private let browseQueue = OperationQueue()
     private let fileOperationsQueue = OperationQueue()
-    private let browseSession: NMSSHSession
-    private let fileOperationsSession: NMSSHSession
     private let thumbnailQueue = OperationQueue()
-    
-    // The pool of reusable sessions for thumbnails
-    private var thumbnailSessionPool: [NMSSHSession] = []
-    // A semaphore to limit concurrent access to the pool
-    private let poolSemaphore: DispatchSemaphore
-    // A lock to protect modifications to the thumbnailSessionPool array
-    private let poolLock = NSLock()
-    
-    private let hostWithPort: String
+
+    private let host: String
+    private let port: Int
     private let user: String
     private let password: String
-    
+
+    // Main SFTP clients for browsing and file operations
+    private var browseClient: SFTPClient?
+    private var fileOperationsClient: SFTPClient?
+
+    // Session pool for thumbnail downloads
+    private var thumbnailPool: SftpSessionPool?
+
     // A dictionary to track ongoing and queued download operations by their URL.
     private var downloadTasks: [URL: Operation] = [:]
     // A lock to make the downloadTasks dictionary thread-safe.
     private let downloadTasksLock = NSLock()
-    
+
     // MARK: Setup / Cleanup
-    
-    init(name: String, host: String, port: UInt16?, user: String, password: String, path: String) throws {
+
+    init(name: String, host: String, port: UInt16?, user: String, password: String, path: String) async throws {
         self.name = name
-        
-        let hostWithPort = port != nil ? "\(host):\(port!)" : host
-        self.browseSession = try type(of: self).initSession(host: hostWithPort, user: user, password: password)
-        self.fileOperationsSession = try type(of: self).initSession(host: hostWithPort, user: user, password: password)
-        
-        self.hostWithPort = hostWithPort
+        self.host = host
+        self.port = Int(port ?? 22)
         self.user = user
         self.password = password
-        
-        // Initialize the semaphore with the pool size
-        self.poolSemaphore = DispatchSemaphore(value: thumbnailSessionPoolSize)
-        
+
         let directoryPath = path.hasSuffix("/") ? path : path + "/"
-        guard let rootUrl = URL.url(scheme: "sftp", host: host, port: port, user: user, path: directoryPath) else { throw SftpError.rootUrlInitializationFailed }
+        guard let rootUrl = URL.url(scheme: "sftp", host: host, port: port, user: user, path: directoryPath) else {
+            throw SftpError.rootUrlInitializationFailed
+        }
         self.rootUrl = rootUrl
-        
+
         self.browseQueue.maxConcurrentOperationCount = 1
         self.browseQueue.qualityOfService = .userInteractive
         self.fileOperationsQueue.maxConcurrentOperationCount = 1
         self.fileOperationsQueue.qualityOfService = .userInitiated
-        self.thumbnailQueue.maxConcurrentOperationCount = thumbnailConcurrentOprationCount
+        self.thumbnailQueue.maxConcurrentOperationCount = thumbnailConcurrentOperationCount
         self.thumbnailQueue.qualityOfService = .utility
-        
-        super.init() // Call super.init() before initializing the pool
-        
-        Logger.filesystem.debug("Initializing thumbnail session pool with size \(self.thumbnailSessionPoolSize, privacy: .public)...")
-        // Create the initial pool of sessions
-        for i in 0 ..< thumbnailSessionPoolSize {
-            do {
-                let session = try type(of: self).initSession(host: self.hostWithPort, user: self.user, password: self.password)
-                self.thumbnailSessionPool.append(session)
-            } catch {
-                Logger.filesystem.error("Failed to create initial session \(i+1, privacy: .public)/\(self.thumbnailSessionPoolSize, privacy: .public): \(error.localizedDescription, privacy: .public)")
-                // If one fails, we just continue with a smaller pool.
-                // We must release the semaphore "permit" for the session we failed to create.
-                self.poolSemaphore.wait() // Consume the permit for the failed session
-            }
-        }
-        Logger.filesystem.debug("Thumbnail session pool initialized with \(self.thumbnailSessionPool.count, privacy: .public) sessions.")
+
+        super.init()
+
+        // Initialize SSH connections
+        Logger.filesystem.debug("Connecting to SFTP server at \(host, privacy: .public):\(self.port, privacy: .public)")
+
+        self.browseClient = try await Self.createSftpClient(host: host, port: self.port, user: user, password: password)
+        self.fileOperationsClient = try await Self.createSftpClient(host: host, port: self.port, user: user, password: password)
+
+        Logger.filesystem.debug("Main SFTP clients connected")
+
+        // Initialize thumbnail session pool
+        self.thumbnailPool = try await SftpSessionPool(
+            host: host,
+            port: self.port,
+            user: user,
+            password: password,
+            poolSize: thumbnailSessionPoolSize
+        )
+
+        Logger.filesystem.debug("SftpFileSystem initialization complete")
     }
-    
+
     deinit {
-        Logger.filesystem.debug("SftpFileSystem deinit: Cancelling all thumbnail operations.")
+        Logger.filesystem.debug("SftpFileSystem deinit: Cancelling all operations and closing connections")
         thumbnailQueue.cancelAllOperations()
+
+        // Close clients in a detached task since deinit can't be async
+        let browseClient = self.browseClient
+        let fileOpsClient = self.fileOperationsClient
+        let pool = self.thumbnailPool
+
+        Task.detached {
+            try? await browseClient?.close()
+            try? await fileOpsClient?.close()
+            await pool?.shutdown()
+        }
     }
-    
-    private static func initSession(host: String, user: String, password: String) throws -> NMSSHSession {
-        guard let session = NMSSHSession.connect(toHost: host, withUsername: user) else { throw SftpError.connectionFailed }
-        guard session.isConnected else { throw SftpError.connectionFailed }
-        
-        session.authenticate(byPassword: password)
-        guard session.isAuthorized else { throw SftpError.authenticationFailed }
-        
-        session.sftp.connect()
-        guard session.sftp.isConnected else { throw SftpError.sftpInitializationFailed }
-        
-        return session
+
+    private static func createSftpClient(host: String, port: Int, user: String, password: String) async throws -> SFTPClient {
+        let ssh = try await SSHClient.connect(
+            host: host,
+            port: port,
+            authenticationMethod: .passwordBased(username: user, password: password),
+            hostKeyValidator: .acceptAnything(),
+            reconnect: .never
+        )
+        return try await ssh.openSFTP()
     }
-    
-    
+
     // MARK: FileSystem
-    
+
     func load(_ url: URL, completionHandler: @escaping (([FileItem]?, Int64?, Error?) -> Void)) {
         assert(isUnderRoot(url) || url == self.rootUrl, "URL (\(url)) is outside root tree (\(self.rootUrl)).")
-        
-        browseQueue.addOperation {[weak self] in
-            guard let `self` = self else { return }
-            do {
-                let rawContents = self.browseSession.sftp.contentsOfDirectory(atPath: url.path)
-                guard let contents = rawContents as? [NMSFTPFile] else { throw SftpError.invalidDirectoryContent(at: url) }
-                let fileItems = contents.compactMap { return FileItem(sftpFile: $0, parentUrl: url, user: self.browseSession.username ?? "") }
-                let freeSpace = self.browseSession.channel.freeSpace(at: url.path)
-                DispatchQueue.main.async { completionHandler(fileItems, freeSpace, nil) }
+
+        browseQueue.addOperation { [weak self] in
+            guard let self = self, let client = self.browseClient else {
+                DispatchQueue.main.async { completionHandler(nil, nil, SftpError.connectionFailed) }
+                return
             }
-            catch {
-                print("\(String(describing: self.browseSession.lastError))")
-                print("\(String(describing: self.browseSession.sftp.lastError))")
-                DispatchQueue.main.async { completionHandler(nil, nil, error) }
+
+            Task {
+                do {
+                    let contents = try await client.listDirectory(atPath: url.path)
+                    let fileItems = contents.flatMap { name -> [FileItem] in
+                        name.components.compactMap { component in
+                            FileItem(sftpComponent: component, parentUrl: url)
+                        }
+                    }
+                    // Free space not available through Citadel SFTP
+                    DispatchQueue.main.async { completionHandler(fileItems, nil, nil) }
+                } catch {
+                    Logger.filesystem.error("Failed to list directory \(url.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    DispatchQueue.main.async { completionHandler(nil, nil, error) }
+                }
             }
         }
     }
-    
+
     func delete(_ url: URL) -> FileOperation {
         _ = canDelete(url, assertOnFailure: true)
-        
+
         let operation = FileOperation(operation: .delete, source: url)
         operation.sourceState = .inProgress
         operation.addExecutionBlock { [weak self] in
-            guard let `self` = self else { return }
-            do {
-                try self.deleteRemote(at: url)
-                operation.sourceState = .deleted
-            }
-            catch {
-                operation.error = error
+            guard let self = self, let client = self.fileOperationsClient else {
+                operation.error = SftpError.connectionFailed
                 operation.sourceState = .present
+                return
             }
+
+            let semaphore = DispatchSemaphore(value: 0)
+            Task {
+                do {
+                    try await self.deleteRemote(at: url, using: client)
+                    operation.sourceState = .deleted
+                } catch {
+                    operation.error = error
+                    operation.sourceState = .present
+                }
+                semaphore.signal()
+            }
+            semaphore.wait()
         }
         self.fileOperationsQueue.addOperation(operation)
         return operation
     }
-    
+
     func copy(_ srcUrl: URL, to destUrl: URL) -> FileOperation {
         _ = canCopy(srcUrl, to: destUrl, assertOnFailure: true)
-        
+
         let operation = FileOperation(operation: .copy, source: srcUrl, destination: destUrl)
         operation.destinationState = .inProgress
         operation.addExecutionBlock { [weak self] in
-            guard let `self` = self else { return }
-            do {
-                let progress: DownloadProgress = { _, _ in return !operation.isCancelled }
-                
-                let destUrl = try self.nonExistingUrl(for: destUrl)
-                operation.destination = destUrl
-                self.willAddFile(at: destUrl, from: operation)
-                
-                if self.isUnderRoot(srcUrl) && self.isUnderRoot(destUrl) {
-                    guard self.fileOperationsSession.sftp.copyContents(ofPath: srcUrl.path, toFileAtPath: destUrl.path, progress: progress) else { throw SftpError.copyingFileFailed(from: srcUrl, to: destUrl) }
-                }
-                else if self.isUnderRoot(srcUrl) {
-                    try self.download(from: srcUrl, to: destUrl, progress: progress)
-                }
-                else if self.isUnderRoot(destUrl) {
-                    try self.upload(from: srcUrl, to: destUrl)
-                }
-                operation.destinationState = .present
-            }
-            catch {
-                operation.error = error
+            guard let self = self, let client = self.fileOperationsClient else {
+                operation.error = SftpError.connectionFailed
                 operation.destinationState = .deleted
+                return
             }
+
+            let semaphore = DispatchSemaphore(value: 0)
+            Task {
+                do {
+                    let finalDestUrl = try await self.nonExistingUrl(for: destUrl, using: client)
+                    operation.destination = finalDestUrl
+                    self.willAddFile(at: finalDestUrl, from: operation)
+
+                    if self.isUnderRoot(srcUrl) && self.isUnderRoot(finalDestUrl) {
+                        // Remote to remote copy: read then write
+                        try await self.copyRemoteToRemote(from: srcUrl, to: finalDestUrl, using: client, isCancelled: { operation.isCancelled })
+                    } else if self.isUnderRoot(srcUrl) {
+                        // Download from remote
+                        try await self.download(from: srcUrl, to: finalDestUrl, using: client, isCancelled: { operation.isCancelled })
+                    } else if self.isUnderRoot(finalDestUrl) {
+                        // Upload to remote
+                        try await self.upload(from: srcUrl, to: finalDestUrl, using: client, isCancelled: { operation.isCancelled })
+                    }
+                    operation.destinationState = .present
+                } catch {
+                    operation.error = error
+                    operation.destinationState = .deleted
+                }
+                semaphore.signal()
+            }
+            semaphore.wait()
         }
         self.fileOperationsQueue.addOperation(operation)
         return operation
     }
-    
+
     func move(_ srcUrl: URL, to destUrl: URL) -> FileOperation {
         _ = canMove(srcUrl, to: destUrl, assertOnFailure: true)
-        
+
         let operation = FileOperation(operation: .move, source: srcUrl, destination: destUrl)
         operation.sourceState = .inProgress
         operation.destinationState = .inProgress
-        operation.addExecutionBlock {[weak self] in
-            guard let `self` = self else { return }
-            do {
-                let destUrl = try self.nonExistingUrl(for: destUrl)
-                operation.destination = destUrl
-                self.willAddFile(at: destUrl, from: operation)
-                
-                guard self.fileOperationsSession.sftp.moveItem(atPath: srcUrl.path, toPath: destUrl.path) else { throw SftpError.movingFileFailed(from: srcUrl, to: destUrl) }
-                operation.sourceState = .deleted
-                operation.destinationState = .present
-            }
-            catch {
-                operation.error = error
+        operation.addExecutionBlock { [weak self] in
+            guard let self = self, let client = self.fileOperationsClient else {
+                operation.error = SftpError.connectionFailed
                 operation.sourceState = .present
                 operation.destinationState = .deleted
+                return
             }
+
+            let semaphore = DispatchSemaphore(value: 0)
+            Task {
+                do {
+                    let finalDestUrl = try await self.nonExistingUrl(for: destUrl, using: client)
+                    operation.destination = finalDestUrl
+                    self.willAddFile(at: finalDestUrl, from: operation)
+
+                    try await client.rename(at: srcUrl.path, to: finalDestUrl.path)
+                    operation.sourceState = .deleted
+                    operation.destinationState = .present
+                } catch {
+                    operation.error = error
+                    operation.sourceState = .present
+                    operation.destinationState = .deleted
+                }
+                semaphore.signal()
+            }
+            semaphore.wait()
         }
         self.fileOperationsQueue.addOperation(operation)
         return operation
     }
-    
+
     func createFolder(_ url: URL) -> FileOperation {
         _ = canCreateFolder(url, assertOnFailure: true)
-        
+
         let operation = FileOperation(operation: .createFolder, destination: url)
         operation.destinationState = .inProgress
-        operation.addExecutionBlock {
-            do {
-                let url = try self.nonExistingUrl(for: url)
-                operation.destination = url
-                self.willAddFile(at: url, from: operation)
-                
-                guard self.fileOperationsSession.sftp.createDirectory(atPath: url.path) else { throw SftpError.creatingDirectoryFailed(at: url) }
-                operation.destinationState = .present
-            }
-            catch {
-                operation.error = error
+        operation.addExecutionBlock { [weak self] in
+            guard let self = self, let client = self.fileOperationsClient else {
+                operation.error = SftpError.connectionFailed
                 operation.destinationState = .deleted
+                return
             }
+
+            let semaphore = DispatchSemaphore(value: 0)
+            Task {
+                do {
+                    let finalUrl = try await self.nonExistingUrl(for: url, using: client)
+                    operation.destination = finalUrl
+                    self.willAddFile(at: finalUrl, from: operation)
+
+                    try await client.createDirectory(atPath: finalUrl.path)
+                    operation.destinationState = .present
+                } catch {
+                    operation.error = error
+                    operation.destinationState = .deleted
+                }
+                semaphore.signal()
+            }
+            semaphore.wait()
         }
         self.fileOperationsQueue.addOperation(operation)
         return operation
     }
-    
-    // MARK: Session Pool Management
-    
-    ///Acquires a reusable session from the pool. Blocks if the pool is empty.
-    private func acquireThumbnailSession() -> NMSSHSession {
-        // Wait until a session is available (blocks the current Operation, not the main thread)
-        poolSemaphore.wait()
-        
-        poolLock.lock()
-        // We are guaranteed to have a session because the semaphore controls access
-        let session = thumbnailSessionPool.removeFirst()
-        poolLock.unlock()
-        
-        Logger.filesystem.debug("Session acquired. Pool size: \(self.thumbnailSessionPool.count, privacy: .public)")
-        return session
-    }
-    
-    ///Returns a healthy session to the pool.
-    private func releaseThumbnailSession(_ session: NMSSHSession) {
-        poolLock.lock()
-        thumbnailSessionPool.append(session)
-        poolLock.unlock()
-        
-        // Release the semaphore permit
-        poolSemaphore.signal()
-        Logger.filesystem.debug("Session released. Pool size: \(self.thumbnailSessionPool.count, privacy: .public)")
-    }
-    
-    ///Discards a dead session and tries to replace it with a new one.
-    ///Always releases the semaphore permit.
-    private func replaceThumbnailSession(_ deadSession: NMSSHSession) {
-        Logger.filesystem.debug("Replacing dead session...")
-        deadSession.disconnect()
-        
-        asynchronouslyRecreateAndAddSession()
-    }
-    
-    private func asynchronouslyRecreateAndAddSession() {
-        DispatchQueue.global(qos: .utility).async { [weak self] in
-            guard let self = self else { return }
-            
-            let retryInterval: TimeInterval = 5.0
-            
-            while true {
-                Logger.filesystem.debug("Attempting to recreate a session...")
-                do {
-                    let newSession = try type(of: self).initSession(
-                        host: self.hostWithPort,
-                        user: self.user,
-                        password: self.password
-                    )
-                    
-                    Logger.filesystem.debug("Session recreated successfully.")
-                    self.poolLock.lock()
-                    self.thumbnailSessionPool.append(newSession)
-                    self.poolLock.unlock()
-                    
-                    self.poolSemaphore.signal()
-                    
-                    break
-                } catch {
-                    Logger.filesystem.error("Failed to recreate session: \(error.localizedDescription, privacy: .public). Retrying in \(retryInterval, privacy: .public)s...")
-                    Thread.sleep(forTimeInterval: retryInterval)
-                }
-            }
+
+    // MARK: Private - Remote Operations
+
+    /// Check if a remote path exists and return its attributes, or nil if it doesn't exist.
+    private func getAttributesIfExists(at path: String, using client: SFTPClient) async -> SFTPFileAttributes? {
+        do {
+            return try await client.getAttributes(at: path)
+        } catch {
+            return nil
         }
     }
-    
-    // MARK: Private stuff
-    
-    /// Return the same given URL or an alternative that does not yet exist
-    private func nonExistingUrl(for url: URL) throws -> URL {
+
+    /// Check if a remote file exists.
+    private func fileExists(at path: String, using client: SFTPClient) async -> Bool {
+        guard let attrs = await getAttributesIfExists(at: path, using: client) else { return false }
+        // Check it's not a directory
+        return attrs.permissions.map { $0 & 0o40000 == 0 } ?? true
+    }
+
+    /// Check if a remote directory exists.
+    private func directoryExists(at path: String, using client: SFTPClient) async -> Bool {
+        guard let attrs = await getAttributesIfExists(at: path, using: client) else { return false }
+        // Check it's a directory
+        return attrs.permissions.map { $0 & 0o40000 != 0 } ?? false
+    }
+
+    /// Return the same given URL or an alternative that does not yet exist.
+    private func nonExistingUrl(for url: URL, using client: SFTPClient) async throws -> URL {
         var url = url
-        
+
         if isUnderRoot(url) {
-            while self.fileOperationsSession.sftp.fileExists(atPath: url.regularFileURL.path) || self.fileOperationsSession.sftp.directoryExists(atPath: url.regularFileURL.path) {
+            while await remotePathExists(at: url.regularFileURL.path, using: client) {
                 url = url.alternativeForDuplicate()
             }
             return url
-        }
-        else if url.isFileURL {
+        } else if url.isFileURL {
             while FileManager.default.fileExists(atPath: url.regularFileURL.path) {
                 url = url.alternativeForDuplicate()
             }
             return url
-        }
-        else {
+        } else {
             throw FileSystemError.invalidUrl(url: url)
         }
     }
-    
-    /// Make sure there is required directory on local file system
-    private func ensureLocalDirectory(at url: URL) throws {
-        var url = url
-        var existsDirectory: ObjCBool = false
-        if !FileManager.default.fileExists(atPath: url.path, isDirectory: &existsDirectory) {
-            url = try nonExistingUrl(for: url)
-        }
-        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
+
+    /// Check if a remote path exists (either file or directory).
+    private func remotePathExists(at path: String, using client: SFTPClient) async -> Bool {
+        return await getAttributesIfExists(at: path, using: client) != nil
     }
-    
-    /// Synchronously download remote file or directory to local destination.
-    private func download(from srcUrl: URL, to destUrl: URL, progress: DownloadProgress?) throws {
-        assert(isUnderRoot(srcUrl), "Source URL (\(srcUrl)) expected to be under root (\(self.rootUrl)).")
-        assert(destUrl.isFileURL, "Destination URL (\(destUrl)) expected to be local URL.")
-        
-        if srcUrl.hasDirectoryPath {
-            try downloadDirectory(from: srcUrl, to: destUrl, progress: progress)
-        }
-        else {
-            let destUrl = try nonExistingUrl(for: destUrl)
-            guard let stream = OutputStream(url: destUrl, append: false) else { throw SftpError.openOutputStreamFailed(at: srcUrl) }
-            guard self.fileOperationsSession.sftp.readFile(atPath: srcUrl.path, to: stream, progress: progress) else { throw SftpError.copyingFileFailed(from: srcUrl, to: destUrl) }
-        }
-    }
-    
-    /// Synchromously donwload remote directory to local destination.
-    private func downloadDirectory(from srcUrl: URL, to destUrl: URL, progress: DownloadProgress?) throws {
-        assert(isUnderRoot(srcUrl), "Source URL (\(srcUrl)) expected to be under root (\(self.rootUrl)).")
-        assert(srcUrl.hasDirectoryPath, "Source URL (\(srcUrl)) expected to be a directory.")
-        assert(destUrl.isFileURL, "Destination URL (\(destUrl)) expected to be local directory URL.")
-        
-        guard let files = self.fileOperationsSession.sftp.contentsOfDirectory(atPath: srcUrl.path) as? [NMSFTPFile] else { throw SftpError.invalidDirectoryContent(at: srcUrl) }
-        
-        try ensureLocalDirectory(at: destUrl)
-        
-        for file in files {
-            guard let filename = file.filename else { assertionFailure("File name expected to be non-nil."); continue }
-            let fileSrcUrl = srcUrl.appendingPathComponent(filename, isDirectory: file.isDirectory)
-            let fileDestUrl = destUrl.appendingPathComponent(filename, isDirectory: file.isDirectory)
-            try download(from: fileSrcUrl, to: fileDestUrl, progress: progress)
-        }
-    }
-    
-    /// Make sure there is required directory on remote file system
-    private func ensureRemoteDirectory(at url: URL) throws {
-        assert(isUnderRoot(url), "URL (\(url)) expected to be under root (\(self.rootUrl)).")
-        
-        var url = url
-        if self.fileOperationsSession.sftp.fileExists(atPath: url.path) {
-            url = try nonExistingUrl(for: url)
-        }
-        guard !self.fileOperationsSession.sftp.directoryExists(atPath: url.path) else { return }
-        guard self.fileOperationsSession.sftp.createDirectory(atPath: url.path) else { throw SftpError.creatingDirectoryFailed(at: url) }
-    }
-    
-    /// Synchronously upload local file or directory to remote destination.
-    private func upload(from srcUrl: URL, to destUrl: URL) throws {
-        assert(srcUrl.isFileURL, "Source URL (\(srcUrl)) expected to be local directory URL.")
-        assert(isUnderRoot(destUrl), "Destination URL (\(destUrl)) expected to be under root (\(self.rootUrl)).")
-        
-        if srcUrl.hasDirectoryPath {
-            try uploadDirectory(from: srcUrl, to: destUrl)
-        }
-        else {
-            let destUrl = try nonExistingUrl(for: destUrl)
-            var started: Bool = false
-            let progress: UploadProgress = { _ in
-                if !started {
-                    started = true
-                }
-                return true
-            }
-            guard let stream = InputStream(url: srcUrl) else { throw SftpError.openInputStreamFailed(at: srcUrl) }
-            guard self.fileOperationsSession.sftp.write(stream, toFileAtPath: destUrl.path, progress: progress) else { throw SftpError.copyingFileFailed(from: srcUrl, to: destUrl) }
-        }
-    }
-    
-    /// Synchromously upload local directory to remote destination.
-    private func uploadDirectory(from srcUrl: URL, to destUrl: URL) throws {
-        assert(srcUrl.isFileURL, "Source URL (\(srcUrl)) expected to be local directory URL.")
-        assert(srcUrl.hasDirectoryPath, "Source URL (\(srcUrl)) expected to be a directory.")
-        assert(isUnderRoot(destUrl), "Destination URL (\(destUrl)) expected to be under root (\(self.rootUrl)).")
-        
-        let files = try FileManager.default.contentsOfDirectory(at: srcUrl, includingPropertiesForKeys: nil, options: [.skipsPackageDescendants, .skipsSubdirectoryDescendants])
-        
-        try ensureRemoteDirectory(at: destUrl)
-        
-        for fileSrcUrl in files {
-            let fileDestUrl = fileSrcUrl.movedTo(destUrl)
-            try upload(from: fileSrcUrl, to: fileDestUrl)
-        }
-    }
-    
-    /// Synchromously delete remote item, be it a file or a possibly non-empty directory
-    private func deleteRemote(at url: URL) throws {
+
+    /// Delete a remote file or directory.
+    private func deleteRemote(at url: URL, using client: SFTPClient) async throws {
         assert(isUnderRoot(url), "URL being deleted (\(url)) expected to be under root (\(self.rootUrl)).")
-        
+
         if url.hasDirectoryPath {
-            try deleteRemoteDirectory(at: url)
-        }
-        else {
-            guard self.fileOperationsSession.sftp.removeFile(atPath: url.path) else { throw SftpError.deletingFileFailed(at: url) }
+            try await deleteRemoteDirectory(at: url, using: client)
+        } else {
+            try await client.remove(at: url.path)
         }
     }
-    
-    /// Synchronously delete possibly non-empty remote directory
-    private func deleteRemoteDirectory(at url: URL) throws {
+
+    /// Delete a possibly non-empty remote directory.
+    private func deleteRemoteDirectory(at url: URL, using client: SFTPClient) async throws {
         assert(isUnderRoot(url), "URL being deleted (\(url)) expected to be under root (\(self.rootUrl)).")
         assert(url.hasDirectoryPath, "URL being deleted (\(url)) expected to be a directory.")
-        
-        let session = self.fileOperationsSession
-        
-        // first try delete directly
-        if session.sftp.removeDirectory(atPath: url.path) {
+
+        // First try to delete directly (works for empty directories)
+        do {
+            try await client.rmdir(at: url.path)
             return
+        } catch {
+            // May fail on non-empty directory, try recursive delete
         }
-        
-        // However direct delete may fail on non-empty directory with SFTP error 4 (Failure). In such case try deleteing children manually.
-        
-        switch session.lastError {
-        case let err as NSError: guard Int32(err.code) == LIBSSH2_ERROR_SFTP_PROTOCOL else { throw session.lastError }
-        default: throw session.lastError
+
+        // List and delete children
+        let contents = try await client.listDirectory(atPath: url.path)
+        for name in contents {
+            for component in name.components {
+                let filename = component.filename
+                guard filename != "." && filename != ".." else { continue }
+                let isDir = component.attributes.permissions.map { $0 & 0o40000 != 0 } ?? false
+                let fileUrl = url.appendingPathComponent(filename, isDirectory: isDir)
+                try await deleteRemote(at: fileUrl, using: client)
+            }
         }
-        
-        switch session.sftp.lastError {
-        case let err as NSError: guard Int32(err.code) == LIBSSH2_FX_FAILURE else { throw session.sftp.lastError }
-        default: throw session.sftp.lastError
-        }
-        
-        // Delete children
-        guard let files = session.sftp.contentsOfDirectory(atPath: url.path) as? [NMSFTPFile] else { throw SftpError.invalidDirectoryContent(at: url) }
-        for file in files {
-            guard let filename = file.filename else { assertionFailure("File name expected to be non-nil."); continue }
-            let fileUrl = url.appendingPathComponent(filename, isDirectory: file.isDirectory)
-            try deleteRemote(at: fileUrl)
-        }
-        
-        // Try again to delete directory
-        guard session.sftp.removeDirectory(atPath: url.path) else { throw SftpError.deletingFileFailed(at: url) }
+
+        // Try again to delete now-empty directory
+        try await client.rmdir(at: url.path)
     }
-    
-    /// Perform notification about starting to add new file (file name might be different than requested)
+
+    /// Copy a remote file to another remote location (read + write).
+    private func copyRemoteToRemote(from srcUrl: URL, to destUrl: URL, using client: SFTPClient, isCancelled: @escaping () -> Bool) async throws {
+        if srcUrl.hasDirectoryPath {
+            // Create destination directory
+            try await client.createDirectory(atPath: destUrl.path)
+
+            // Copy children
+            let contents = try await client.listDirectory(atPath: srcUrl.path)
+            for name in contents {
+                for component in name.components {
+                    let filename = component.filename
+                    guard filename != "." && filename != ".." else { continue }
+                    if isCancelled() { throw SftpError.operationCancelled }
+
+                    let isDir = component.attributes.permissions.map { $0 & 0o40000 != 0 } ?? false
+                    let fileSrcUrl = srcUrl.appendingPathComponent(filename, isDirectory: isDir)
+                    let fileDestUrl = destUrl.appendingPathComponent(filename, isDirectory: isDir)
+                    try await copyRemoteToRemote(from: fileSrcUrl, to: fileDestUrl, using: client, isCancelled: isCancelled)
+                }
+            }
+        } else {
+            // Read source file
+            let data = try await client.withFile(filePath: srcUrl.path, flags: .read) { file in
+                try await file.readAll()
+            }
+
+            if isCancelled() { throw SftpError.operationCancelled }
+
+            // Write to destination
+            try await client.withFile(filePath: destUrl.path, flags: [.write, .create, .truncate]) { file in
+                try await file.write(data)
+            }
+        }
+    }
+
+    /// Download a remote file or directory to a local destination.
+    private func download(from srcUrl: URL, to destUrl: URL, using client: SFTPClient, isCancelled: @escaping () -> Bool) async throws {
+        assert(isUnderRoot(srcUrl), "Source URL (\(srcUrl)) expected to be under root (\(self.rootUrl)).")
+        assert(destUrl.isFileURL, "Destination URL (\(destUrl)) expected to be local URL.")
+
+        if srcUrl.hasDirectoryPath {
+            try await downloadDirectory(from: srcUrl, to: destUrl, using: client, isCancelled: isCancelled)
+        } else {
+            let finalDestUrl = try await nonExistingUrl(for: destUrl, using: client)
+
+            // Read remote file
+            let data = try await client.withFile(filePath: srcUrl.path, flags: .read) { file in
+                try await file.readAll()
+            }
+
+            if isCancelled() { throw SftpError.operationCancelled }
+
+            // Write to local file
+            let dataBytes = Data(buffer: data)
+            try dataBytes.write(to: finalDestUrl)
+        }
+    }
+
+    /// Download a remote directory to a local destination.
+    private func downloadDirectory(from srcUrl: URL, to destUrl: URL, using client: SFTPClient, isCancelled: @escaping () -> Bool) async throws {
+        // Create local directory
+        try FileManager.default.createDirectory(at: destUrl, withIntermediateDirectories: true, attributes: nil)
+
+        // List and download children
+        let contents = try await client.listDirectory(atPath: srcUrl.path)
+        for name in contents {
+            for component in name.components {
+                let filename = component.filename
+                guard filename != "." && filename != ".." else { continue }
+                if isCancelled() { throw SftpError.operationCancelled }
+
+                let isDir = component.attributes.permissions.map { $0 & 0o40000 != 0 } ?? false
+                let fileSrcUrl = srcUrl.appendingPathComponent(filename, isDirectory: isDir)
+                let fileDestUrl = destUrl.appendingPathComponent(filename, isDirectory: isDir)
+                try await download(from: fileSrcUrl, to: fileDestUrl, using: client, isCancelled: isCancelled)
+            }
+        }
+    }
+
+    /// Upload a local file or directory to a remote destination.
+    private func upload(from srcUrl: URL, to destUrl: URL, using client: SFTPClient, isCancelled: @escaping () -> Bool) async throws {
+        assert(srcUrl.isFileURL, "Source URL (\(srcUrl)) expected to be local URL.")
+        assert(isUnderRoot(destUrl), "Destination URL (\(destUrl)) expected to be under root (\(self.rootUrl)).")
+
+        if srcUrl.hasDirectoryPath {
+            try await uploadDirectory(from: srcUrl, to: destUrl, using: client, isCancelled: isCancelled)
+        } else {
+            let finalDestUrl = try await nonExistingUrl(for: destUrl, using: client)
+
+            // Read local file
+            let data = try Data(contentsOf: srcUrl)
+
+            if isCancelled() { throw SftpError.operationCancelled }
+
+            // Write to remote
+            var buffer = ByteBuffer()
+            buffer.writeBytes(data)
+            let bufferToWrite = buffer
+            try await client.withFile(filePath: finalDestUrl.path, flags: [.write, .create, .truncate]) { file in
+                try await file.write(bufferToWrite)
+            }
+        }
+    }
+
+    /// Upload a local directory to a remote destination.
+    private func uploadDirectory(from srcUrl: URL, to destUrl: URL, using client: SFTPClient, isCancelled: @escaping () -> Bool) async throws {
+        // Create remote directory
+        try await client.createDirectory(atPath: destUrl.path)
+
+        // List and upload children
+        let contents = try FileManager.default.contentsOfDirectory(at: srcUrl, includingPropertiesForKeys: nil, options: [.skipsPackageDescendants, .skipsSubdirectoryDescendants])
+
+        for fileSrcUrl in contents {
+            if isCancelled() { throw SftpError.operationCancelled }
+            let fileDestUrl = fileSrcUrl.movedTo(destUrl)
+            try await upload(from: fileSrcUrl, to: fileDestUrl, using: client, isCancelled: isCancelled)
+        }
+    }
+
+    /// Perform notification about starting to add new file.
     private func willAddFile(at url: URL, from fileOperation: FileOperation) {
         DispatchQueue.main.async {
             self.delegate?.fileSystem(self, willAddFileAt: url, from: fileOperation)
         }
     }
-    
-    /// Perform notification about deleted file
-//    private func didRemoveFile(at url: URL) {
-//        DispatchQueue.main.async {
-//            self.delegate?.fileSystem(self, didRemoveFileAt: url)
-//        }
-//    }
-    
-    /// Perform notification about added file
-//    private func didAddFile(at url: URL) {
-//        DispatchQueue.main.async {
-//            self.delegate?.fileSystem(self, didAddFileAt: url)
-//        }
-//    }
 
-    // MARK: Data Loading
-    
+    // MARK: Data Loading (Thumbnails)
+
     func loadData(at url: URL, completionHandler: @escaping ((Data?, Error?) -> Void)) {
         assert(isUnderRoot(url), "URL (\(url)) is outside root tree (\(self.rootUrl)).")
-        
-        // This function is called by IconItem to fetch thumbnail data.
-        
+
         // Task Duplicate Check
         downloadTasksLock.lock()
         if downloadTasks[url] != nil {
-            // Duplicated
             downloadTasksLock.unlock()
             Logger.filesystem.debug("SftpFileSystem loadData: Download for \(url.lastPathComponent, privacy: .public) is already queued. Skipping.")
-            // Do not call completionHandler, as the original request will handle it.
             return
         }
         downloadTasksLock.unlock()
-        
-        // new request
+
         let opCount = thumbnailQueue.operationCount
         Logger.filesystem.debug(">>> QUEUEING operation for \(url.lastPathComponent, privacy: .public). Current queue size: \(opCount, privacy: .public)")
-        
+
         let operation = BlockOperation()
-        
+
         operation.addExecutionBlock { [weak self, weak operation] in
             Logger.filesystem.debug(">>> STARTING operation for \(url.lastPathComponent, privacy: .public).")
-            // Check if self or operation are nil, or if operation was cancelled before starting
+
             guard let self = self, let strongOperation = operation, !strongOperation.isCancelled else {
                 Logger.filesystem.debug("SftpFileSystem loadData: Operation was nil or cancelled before starting for \(url.lastPathComponent, privacy: .public).")
                 DispatchQueue.main.async { completionHandler(nil, nil) }
                 return
             }
-            Logger.filesystem.debug("SftpFileSystem loadData: <<< Operation STARTING for \(url.lastPathComponent, privacy: .public) >>>")
-            
-            // 1. Acquire a session from the pool
-            let session = self.acquireThumbnailSession()
-            var sessionIsDead = false
-            
-            var operationError: Error?
-            var readSuccess = false
-            let memoryStream = OutputStream.toMemory()
-            
-            defer {
-                memoryStream.close()
-                // 3. Release or replace the session
-                if sessionIsDead {
-                    self.replaceThumbnailSession(session)
-                } else {
-                    self.releaseThumbnailSession(session)
-                }
-                Logger.filesystem.debug("SftpFileSystem loadData: <<< Operation FINISHED for \(url.lastPathComponent, privacy: .public) >>>")
+
+            guard let pool = self.thumbnailPool else {
+                DispatchQueue.main.async { completionHandler(nil, SftpError.connectionFailed) }
+                return
             }
-            
-            // 2. Download
-            memoryStream.open()
-            
-            Logger.filesystem.debug("SftpFileSystem loadData: Download starting for \(url.lastPathComponent, privacy: .public).")
-            if session.sftp.readFile(atPath: url.path, to: memoryStream, progress: { _, _ in
-                // Abort if a cancellation occurs
-                return !strongOperation.isCancelled
-            }) {
-                readSuccess = true
-                Logger.filesystem.debug("SftpFileSystem loadData: Download success for \(url.lastPathComponent, privacy: .public).")
-            } else {
+
+            let semaphore = DispatchSemaphore(value: 0)
+
+            Task {
+                var session: SFTPClient?
+                var resultData: Data?
+                var resultError: Error?
+
+                defer {
+                    // Return session to pool
+                    if let session = session {
+                        Task { await pool.release(session) }
+                    }
+                    semaphore.signal()
+                }
+
+                do {
+                    session = try await pool.acquire()
+
+                    if strongOperation.isCancelled {
+                        Logger.filesystem.debug("SftpFileSystem loadData: Operation cancelled after acquiring session for \(url.lastPathComponent, privacy: .public).")
+                        return
+                    }
+
+                    Logger.filesystem.debug("SftpFileSystem loadData: Download starting for \(url.lastPathComponent, privacy: .public).")
+
+                    let buffer = try await session!.withFile(filePath: url.path, flags: .read) { file in
+                        try await file.readAll()
+                    }
+
+                    if strongOperation.isCancelled {
+                        Logger.filesystem.debug("SftpFileSystem loadData: Operation cancelled after download for \(url.lastPathComponent, privacy: .public).")
+                        return
+                    }
+
+                    resultData = Data(buffer: buffer)
+                    Logger.filesystem.debug("SftpFileSystem loadData: Download complete. \(resultData?.count ?? 0, privacy: .public) bytes for \(url.lastPathComponent, privacy: .public).")
+
+                } catch {
+                    if !strongOperation.isCancelled {
+                        resultError = error
+                        Logger.filesystem.error("SftpFileSystem loadData: Download failed for \(url.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    }
+                }
+
                 if !strongOperation.isCancelled {
-                    sessionIsDead = true // Download failure, mark the session as potentially dead
-                    operationError = session.sftp.lastError ?? SftpError.downloadingFileFailed(at: url)
-                    Logger.filesystem.debug("""
-                        SftpFileSystem loadData: Download failed for \(url.lastPathComponent, privacy: .public):
-                            \(operationError?.localizedDescription ?? "Unknown SFTP error", privacy: .public)
-                        """)
+                    DispatchQueue.main.async {
+                        completionHandler(resultData, resultError)
+                    }
                 } else {
-                    Logger.filesystem.debug("SftpFileSystem loadData: Download cancelled in progress for \(url.lastPathComponent, privacy: .public).")
+                    DispatchQueue.main.async {
+                        completionHandler(nil, nil)
+                    }
                 }
             }
-            
-            // Final health check
-            if !session.isConnected || !session.sftp.isConnected {
-                Logger.filesystem.debug("Session found disconnected after operation for \(url.lastPathComponent, privacy: .public).")
-                sessionIsDead = true
-            }
-            
-            // Completion Handler
-            
-            // Cancelled
-            if strongOperation.isCancelled {
-                Logger.filesystem.debug("SftpFileSystem loadData: Operation finished but was cancelled for \(url.lastPathComponent, privacy: .public). No callback.")
-                DispatchQueue.main.async { completionHandler(nil, nil) }
-                return
-            }
-            
-            // Failure
-            guard readSuccess, let data = memoryStream.property(forKey: .dataWrittenToMemoryStreamKey) as? Data else {
-                Logger.filesystem.debug("SftpFileSystem loadData: Failed to get data for \(url.lastPathComponent, privacy: .public).")
-                let error = operationError ?? SftpError.downloadingFileFailed(at: url)
-                DispatchQueue.main.async { completionHandler(nil, error) }
-                return
-            }
-            
-            // Success
-            Logger.filesystem.debug("""
-                SftpFileSystem loadData: Download complete.
-                    Returning \(data.count, privacy: .public) bytes for \(url.lastPathComponent, privacy: .public).
-                """)
-            DispatchQueue.main.async { completionHandler(data, nil) }
+
+            semaphore.wait()
+            Logger.filesystem.debug("SftpFileSystem loadData: <<< Operation FINISHED for \(url.lastPathComponent, privacy: .public) >>>")
         }
-        
+
         operation.completionBlock = { [weak self] in
             self?.downloadTasksLock.lock()
             self?.downloadTasks.removeValue(forKey: url)
             Logger.filesystem.debug("SftpFileSystem: Removed task for \(url.lastPathComponent, privacy: .public) from tracking. Remaining: \(self?.downloadTasks.count ?? 0, privacy: .public)")
             self?.downloadTasksLock.unlock()
         }
-        
+
         // Add the operation to the tracking dictionary before queueing it.
         downloadTasksLock.lock()
         downloadTasks[url] = operation
         downloadTasksLock.unlock()
-        
+
         thumbnailQueue.addOperation(operation)
     }
-    
-    ///Cancels any queued or ongoing thumbnail download for the specified URL.
+
+    /// Cancels any queued or ongoing thumbnail download for the specified URL.
     public func cancelLoad(for url: URL) {
         downloadTasksLock.lock()
         defer { downloadTasksLock.unlock() }
-        
+
         if let operation = downloadTasks[url] {
             if !operation.isFinished && !operation.isCancelled {
                 operation.cancel()
@@ -647,73 +794,31 @@ class SftpFileSystem: NSObject, FileSystem, NMSSHSessionDelegate {
 }
 
 
-// MARK: - FileSystem
+// MARK: - FileItem Extension for Citadel
 
 extension FileItem {
-    
-    fileprivate convenience init?(sftpFile: NMSFTPFile, parentUrl: URL, user: String) {
-        guard var name = sftpFile.filename else { return nil }
+
+    fileprivate convenience init?(sftpComponent: SFTPPathComponent, parentUrl: URL) {
+        var name = sftpComponent.filename
+        guard name != "." && name != ".." else { return nil }
         if name.hasSuffix("/") { name = String(name.dropLast()) }
-        
-        let url = parentUrl.appendingPathComponent(name, isDirectory: sftpFile.isDirectory)
-        
-        var flags: Flags = []
-        if sftpFile.isWritable(by: user) { flags.insert(.isWritable) }
-        if sftpFile.isReadable(by: user) { flags.insert(.isReadable) }
-        if sftpFile.isDirectory { flags.insert(.isDirectory) }
+
+        let attrs = sftpComponent.attributes
+        let isDir = attrs.permissions.map { $0 & 0o40000 != 0 } ?? false
+
+        let url = parentUrl.appendingPathComponent(name, isDirectory: isDir)
+
+        var flags: Flags = [.isReadable, .isWritable] // Assume readable/writable
+        if isDir { flags.insert(.isDirectory) }
         if name.hasPrefix(".") { flags.insert(.isHidden) }
-        
+
         let fileType = flags.contains(.isDirectory) ? UTType.folder : UTType(filenameExtension: url.pathExtension) ?? .data
         let icon = NSWorkspace.shared.icon(for: fileType)
-        
-        let fileSize = sftpFile.fileSize?.int64Value ?? 0
-        
-        let modate = sftpFile.modificationDate
-        
+
+        let fileSize = Int64(attrs.size ?? 0)
+
+        let modate: Date? = attrs.accessModificationTime?.modificationTime
+
         self.init(url: url, name: name, icon: icon, flags: flags, fileSize: fileSize, modate: modate)
     }
-    
-}
-
-
-// MARK: - NMSFTPFile
-
-extension NMSFTPFile {
-    
-    fileprivate func isReadable(by user: String) -> Bool {
-        return true
-    }
-    
-    fileprivate func isWritable(by user: String) -> Bool {
-        return true
-    }
-    
-}
-
-
-// MARK: - NMSSHSession
-
-extension NMSSHChannel {
-    
-    func freeSpace(at path: String) -> Int64? {
-        return nil
-        
-        /*do {
-            let output = try execute("df \(path.replacingOccurrences(of: " ", with: "\\ ")) | tail -1 | awk '{ print $4 }' ")
-            let outputLines = output.components(separatedBy: "\n")
-            guard outputLines.count > 0 else { assertionFailure("Expected non-empty response"); return nil }
-            
-            var space: AnyObject? = nil
-            var error: NSString? = nil
-            let formatter = ByteCountFormatter()
-            guard formatter.getObjectValue(&space, for: outputLines[0], errorDescription: &error) else { assertionFailure("Failed to retrieve free space for path [\(path)], got response: \(output)"); return nil }
-            guard let number = space as? NSNumber else { assertionFailure("Unexepected parsed byte count object type: \(type(of: space))"); return nil }
-            return number.int64Value
-        }
-        catch {
-            Logger.filesystem.error("Failed to retrieve free disk space for path [\(path, privacy: .public)]: \(error, privacy: .public).")
-            return nil
-        }*/
-    }
-    
 }

--- a/Soduto Files/SftpFileSystem.swift
+++ b/Soduto Files/SftpFileSystem.swift
@@ -23,18 +23,18 @@ private actor SftpSessionPool {
     private let user: String
     private let password: String
     private let poolSize: Int
-
+    
     private var sessions: [SFTPClient] = []
     private var waiters: [CheckedContinuation<SFTPClient, Error>] = []
     private var isShuttingDown = false
-
+    
     init(host: String, port: Int, user: String, password: String, poolSize: Int) async throws {
         self.host = host
         self.port = port
         self.user = user
         self.password = password
         self.poolSize = poolSize
-
+        
         // Create initial sessions
         for i in 0..<poolSize {
             do {
@@ -46,10 +46,10 @@ private actor SftpSessionPool {
                 // Continue with smaller pool
             }
         }
-
+        
         Logger.filesystem.debug("Session pool initialized with \(self.sessions.count, privacy: .public) sessions")
     }
-
+    
     private static func createSession(host: String, port: Int, user: String, password: String) async throws -> SFTPClient {
         let ssh = try await SSHClient.connect(
             host: host,
@@ -60,13 +60,13 @@ private actor SftpSessionPool {
         )
         return try await ssh.openSFTP()
     }
-
+    
     /// Acquire a session from the pool. Suspends if none available.
     func acquire() async throws -> SFTPClient {
         if isShuttingDown {
             throw SftpFileSystem.SftpError.connectionFailed
         }
-
+        
         // If we have an available session, return it
         if !sessions.isEmpty {
             let session = sessions.removeFirst()
@@ -79,21 +79,21 @@ private actor SftpSessionPool {
                 return try await acquire()
             }
         }
-
+        
         // No sessions available, wait for one
         return try await withCheckedThrowingContinuation { continuation in
             waiters.append(continuation)
             Logger.filesystem.debug("Session pool: No sessions available, waiting. Waiters: \(self.waiters.count, privacy: .public)")
         }
     }
-
+    
     /// Release a session back to the pool.
     func release(_ session: SFTPClient) {
         guard !isShuttingDown else {
             Task { try? await session.close() }
             return
         }
-
+        
         // If there are waiters, give them the session directly
         if !waiters.isEmpty {
             let waiter = waiters.removeFirst()
@@ -113,7 +113,7 @@ private actor SftpSessionPool {
             }
             return
         }
-
+        
         // No waiters, return to pool if healthy
         if session.isActive {
             sessions.append(session)
@@ -131,7 +131,7 @@ private actor SftpSessionPool {
             }
         }
     }
-
+    
     private func addSession(_ session: SFTPClient) {
         if !waiters.isEmpty {
             let waiter = waiters.removeFirst()
@@ -140,23 +140,23 @@ private actor SftpSessionPool {
             sessions.append(session)
         }
     }
-
+    
     /// Shutdown the pool and close all sessions.
     func shutdown() async {
         isShuttingDown = true
-
+        
         // Fail all waiters
         for waiter in waiters {
             waiter.resume(throwing: SftpFileSystem.SftpError.connectionFailed)
         }
         waiters.removeAll()
-
+        
         // Close all sessions
         for session in sessions {
             try? await session.close()
         }
         sessions.removeAll()
-
+        
         Logger.filesystem.debug("Session pool: Shutdown complete")
     }
 }
@@ -166,9 +166,9 @@ private actor SftpSessionPool {
 class SftpFileSystem: NSObject, FileSystem {
     private let thumbnailConcurrentOperationCount = 16
     private let thumbnailSessionPoolSize = 6
-
+    
     // MARK: Types
-
+    
     enum SftpError: Error {
         case connectionFailed
         case authenticationFailed
@@ -186,68 +186,68 @@ class SftpFileSystem: NSObject, FileSystem {
         case openOutputStreamFailed(at: URL)
         case operationCancelled
     }
-
+    
     // MARK: Properties
-
+    
     weak var delegate: FileSystemDelegate?
-
+    
     let name: String
     let rootUrl: URL
     let places: [Place] = []
-
+    
     private let browseQueue = OperationQueue()
     private let fileOperationsQueue = OperationQueue()
     private let thumbnailQueue = OperationQueue()
-
+    
     private let host: String
     private let port: Int
     private let user: String
     private let password: String
-
+    
     // Main SFTP clients for browsing and file operations
     private var browseClient: SFTPClient?
     private var fileOperationsClient: SFTPClient?
-
+    
     // Session pool for thumbnail downloads
     private var thumbnailPool: SftpSessionPool?
-
+    
     // A dictionary to track ongoing and queued download operations by their URL.
     private var downloadTasks: [URL: Operation] = [:]
     // A lock to make the downloadTasks dictionary thread-safe.
     private let downloadTasksLock = NSLock()
-
+    
     // MARK: Setup / Cleanup
-
+    
     init(name: String, host: String, port: UInt16?, user: String, password: String, path: String) async throws {
         self.name = name
         self.host = host
         self.port = Int(port ?? 22)
         self.user = user
         self.password = password
-
+        
         let directoryPath = path.hasSuffix("/") ? path : path + "/"
         guard let rootUrl = URL.url(scheme: "sftp", host: host, port: port, user: user, path: directoryPath) else {
             throw SftpError.rootUrlInitializationFailed
         }
         self.rootUrl = rootUrl
-
+        
         self.browseQueue.maxConcurrentOperationCount = 1
         self.browseQueue.qualityOfService = .userInteractive
         self.fileOperationsQueue.maxConcurrentOperationCount = 1
         self.fileOperationsQueue.qualityOfService = .userInitiated
         self.thumbnailQueue.maxConcurrentOperationCount = thumbnailConcurrentOperationCount
         self.thumbnailQueue.qualityOfService = .utility
-
+        
         super.init()
-
+        
         // Initialize SSH connections
         Logger.filesystem.debug("Connecting to SFTP server at \(host, privacy: .public):\(self.port, privacy: .public)")
-
+        
         self.browseClient = try await Self.createSftpClient(host: host, port: self.port, user: user, password: password)
         self.fileOperationsClient = try await Self.createSftpClient(host: host, port: self.port, user: user, password: password)
-
+        
         Logger.filesystem.debug("Main SFTP clients connected")
-
+        
         // Initialize thumbnail session pool
         self.thumbnailPool = try await SftpSessionPool(
             host: host,
@@ -256,26 +256,26 @@ class SftpFileSystem: NSObject, FileSystem {
             password: password,
             poolSize: thumbnailSessionPoolSize
         )
-
+        
         Logger.filesystem.debug("SftpFileSystem initialization complete")
     }
-
+    
     deinit {
         Logger.filesystem.debug("SftpFileSystem deinit: Cancelling all operations and closing connections")
         thumbnailQueue.cancelAllOperations()
-
+        
         // Close clients in a detached task since deinit can't be async
         let browseClient = self.browseClient
         let fileOpsClient = self.fileOperationsClient
         let pool = self.thumbnailPool
-
+        
         Task.detached {
             try? await browseClient?.close()
             try? await fileOpsClient?.close()
             await pool?.shutdown()
         }
     }
-
+    
     private static func createSftpClient(host: String, port: Int, user: String, password: String) async throws -> SFTPClient {
         let ssh = try await SSHClient.connect(
             host: host,
@@ -286,18 +286,18 @@ class SftpFileSystem: NSObject, FileSystem {
         )
         return try await ssh.openSFTP()
     }
-
+    
     // MARK: FileSystem
-
+    
     func load(_ url: URL, completionHandler: @escaping (([FileItem]?, Int64?, Error?) -> Void)) {
         assert(isUnderRoot(url) || url == self.rootUrl, "URL (\(url)) is outside root tree (\(self.rootUrl)).")
-
+        
         browseQueue.addOperation { [weak self] in
             guard let self = self, let client = self.browseClient else {
                 DispatchQueue.main.async { completionHandler(nil, nil, SftpError.connectionFailed) }
                 return
             }
-
+            
             Task {
                 do {
                     let contents = try await client.listDirectory(atPath: url.path)
@@ -315,10 +315,10 @@ class SftpFileSystem: NSObject, FileSystem {
             }
         }
     }
-
+    
     func delete(_ url: URL) -> FileOperation {
         _ = canDelete(url, assertOnFailure: true)
-
+        
         let operation = FileOperation(operation: .delete, source: url)
         operation.sourceState = .inProgress
         operation.addExecutionBlock { [weak self] in
@@ -327,7 +327,7 @@ class SftpFileSystem: NSObject, FileSystem {
                 operation.sourceState = .present
                 return
             }
-
+            
             let semaphore = DispatchSemaphore(value: 0)
             Task {
                 do {
@@ -344,10 +344,10 @@ class SftpFileSystem: NSObject, FileSystem {
         self.fileOperationsQueue.addOperation(operation)
         return operation
     }
-
+    
     func copy(_ srcUrl: URL, to destUrl: URL) -> FileOperation {
         _ = canCopy(srcUrl, to: destUrl, assertOnFailure: true)
-
+        
         let operation = FileOperation(operation: .copy, source: srcUrl, destination: destUrl)
         operation.destinationState = .inProgress
         operation.addExecutionBlock { [weak self] in
@@ -356,14 +356,14 @@ class SftpFileSystem: NSObject, FileSystem {
                 operation.destinationState = .deleted
                 return
             }
-
+            
             let semaphore = DispatchSemaphore(value: 0)
             Task {
                 do {
                     let finalDestUrl = try await self.nonExistingUrl(for: destUrl, using: client)
                     operation.destination = finalDestUrl
                     self.willAddFile(at: finalDestUrl, from: operation)
-
+                    
                     if self.isUnderRoot(srcUrl) && self.isUnderRoot(finalDestUrl) {
                         // Remote to remote copy: read then write
                         try await self.copyRemoteToRemote(from: srcUrl, to: finalDestUrl, using: client, isCancelled: { operation.isCancelled })
@@ -386,10 +386,10 @@ class SftpFileSystem: NSObject, FileSystem {
         self.fileOperationsQueue.addOperation(operation)
         return operation
     }
-
+    
     func move(_ srcUrl: URL, to destUrl: URL) -> FileOperation {
         _ = canMove(srcUrl, to: destUrl, assertOnFailure: true)
-
+        
         let operation = FileOperation(operation: .move, source: srcUrl, destination: destUrl)
         operation.sourceState = .inProgress
         operation.destinationState = .inProgress
@@ -400,14 +400,14 @@ class SftpFileSystem: NSObject, FileSystem {
                 operation.destinationState = .deleted
                 return
             }
-
+            
             let semaphore = DispatchSemaphore(value: 0)
             Task {
                 do {
                     let finalDestUrl = try await self.nonExistingUrl(for: destUrl, using: client)
                     operation.destination = finalDestUrl
                     self.willAddFile(at: finalDestUrl, from: operation)
-
+                    
                     try await client.rename(at: srcUrl.path, to: finalDestUrl.path)
                     operation.sourceState = .deleted
                     operation.destinationState = .present
@@ -423,10 +423,10 @@ class SftpFileSystem: NSObject, FileSystem {
         self.fileOperationsQueue.addOperation(operation)
         return operation
     }
-
+    
     func createFolder(_ url: URL) -> FileOperation {
         _ = canCreateFolder(url, assertOnFailure: true)
-
+        
         let operation = FileOperation(operation: .createFolder, destination: url)
         operation.destinationState = .inProgress
         operation.addExecutionBlock { [weak self] in
@@ -435,14 +435,14 @@ class SftpFileSystem: NSObject, FileSystem {
                 operation.destinationState = .deleted
                 return
             }
-
+            
             let semaphore = DispatchSemaphore(value: 0)
             Task {
                 do {
                     let finalUrl = try await self.nonExistingUrl(for: url, using: client)
                     operation.destination = finalUrl
                     self.willAddFile(at: finalUrl, from: operation)
-
+                    
                     try await client.createDirectory(atPath: finalUrl.path)
                     operation.destinationState = .present
                 } catch {
@@ -456,9 +456,9 @@ class SftpFileSystem: NSObject, FileSystem {
         self.fileOperationsQueue.addOperation(operation)
         return operation
     }
-
+    
     // MARK: Private - Remote Operations
-
+    
     /// Check if a remote path exists and return its attributes, or nil if it doesn't exist.
     private func getAttributesIfExists(at path: String, using client: SFTPClient) async -> SFTPFileAttributes? {
         do {
@@ -467,25 +467,25 @@ class SftpFileSystem: NSObject, FileSystem {
             return nil
         }
     }
-
+    
     /// Check if a remote file exists.
     private func fileExists(at path: String, using client: SFTPClient) async -> Bool {
         guard let attrs = await getAttributesIfExists(at: path, using: client) else { return false }
         // Check it's not a directory
         return attrs.permissions.map { $0 & 0o40000 == 0 } ?? true
     }
-
+    
     /// Check if a remote directory exists.
     private func directoryExists(at path: String, using client: SFTPClient) async -> Bool {
         guard let attrs = await getAttributesIfExists(at: path, using: client) else { return false }
         // Check it's a directory
         return attrs.permissions.map { $0 & 0o40000 != 0 } ?? false
     }
-
+    
     /// Return the same given URL or an alternative that does not yet exist.
     private func nonExistingUrl(for url: URL, using client: SFTPClient) async throws -> URL {
         var url = url
-
+        
         if isUnderRoot(url) {
             while await remotePathExists(at: url.regularFileURL.path, using: client) {
                 url = url.alternativeForDuplicate()
@@ -500,28 +500,28 @@ class SftpFileSystem: NSObject, FileSystem {
             throw FileSystemError.invalidUrl(url: url)
         }
     }
-
+    
     /// Check if a remote path exists (either file or directory).
     private func remotePathExists(at path: String, using client: SFTPClient) async -> Bool {
         return await getAttributesIfExists(at: path, using: client) != nil
     }
-
+    
     /// Delete a remote file or directory.
     private func deleteRemote(at url: URL, using client: SFTPClient) async throws {
         assert(isUnderRoot(url), "URL being deleted (\(url)) expected to be under root (\(self.rootUrl)).")
-
+        
         if url.hasDirectoryPath {
             try await deleteRemoteDirectory(at: url, using: client)
         } else {
             try await client.remove(at: url.path)
         }
     }
-
+    
     /// Delete a possibly non-empty remote directory.
     private func deleteRemoteDirectory(at url: URL, using client: SFTPClient) async throws {
         assert(isUnderRoot(url), "URL being deleted (\(url)) expected to be under root (\(self.rootUrl)).")
         assert(url.hasDirectoryPath, "URL being deleted (\(url)) expected to be a directory.")
-
+        
         // First try to delete directly (works for empty directories)
         do {
             try await client.rmdir(at: url.path)
@@ -529,7 +529,7 @@ class SftpFileSystem: NSObject, FileSystem {
         } catch {
             // May fail on non-empty directory, try recursive delete
         }
-
+        
         // List and delete children
         let contents = try await client.listDirectory(atPath: url.path)
         for name in contents {
@@ -541,17 +541,17 @@ class SftpFileSystem: NSObject, FileSystem {
                 try await deleteRemote(at: fileUrl, using: client)
             }
         }
-
+        
         // Try again to delete now-empty directory
         try await client.rmdir(at: url.path)
     }
-
+    
     /// Copy a remote file to another remote location (read + write).
     private func copyRemoteToRemote(from srcUrl: URL, to destUrl: URL, using client: SFTPClient, isCancelled: @escaping () -> Bool) async throws {
         if srcUrl.hasDirectoryPath {
             // Create destination directory
             try await client.createDirectory(atPath: destUrl.path)
-
+            
             // Copy children
             let contents = try await client.listDirectory(atPath: srcUrl.path)
             for name in contents {
@@ -559,7 +559,7 @@ class SftpFileSystem: NSObject, FileSystem {
                     let filename = component.filename
                     guard filename != "." && filename != ".." else { continue }
                     if isCancelled() { throw SftpError.operationCancelled }
-
+                    
                     let isDir = component.attributes.permissions.map { $0 & 0o40000 != 0 } ?? false
                     let fileSrcUrl = srcUrl.appendingPathComponent(filename, isDirectory: isDir)
                     let fileDestUrl = destUrl.appendingPathComponent(filename, isDirectory: isDir)
@@ -571,44 +571,44 @@ class SftpFileSystem: NSObject, FileSystem {
             let data = try await client.withFile(filePath: srcUrl.path, flags: .read) { file in
                 try await file.readAll()
             }
-
+            
             if isCancelled() { throw SftpError.operationCancelled }
-
+            
             // Write to destination
             try await client.withFile(filePath: destUrl.path, flags: [.write, .create, .truncate]) { file in
                 try await file.write(data)
             }
         }
     }
-
+    
     /// Download a remote file or directory to a local destination.
     private func download(from srcUrl: URL, to destUrl: URL, using client: SFTPClient, isCancelled: @escaping () -> Bool) async throws {
         assert(isUnderRoot(srcUrl), "Source URL (\(srcUrl)) expected to be under root (\(self.rootUrl)).")
         assert(destUrl.isFileURL, "Destination URL (\(destUrl)) expected to be local URL.")
-
+        
         if srcUrl.hasDirectoryPath {
             try await downloadDirectory(from: srcUrl, to: destUrl, using: client, isCancelled: isCancelled)
         } else {
             let finalDestUrl = try await nonExistingUrl(for: destUrl, using: client)
-
+            
             // Read remote file
             let data = try await client.withFile(filePath: srcUrl.path, flags: .read) { file in
                 try await file.readAll()
             }
-
+            
             if isCancelled() { throw SftpError.operationCancelled }
-
+            
             // Write to local file
             let dataBytes = Data(buffer: data)
             try dataBytes.write(to: finalDestUrl)
         }
     }
-
+    
     /// Download a remote directory to a local destination.
     private func downloadDirectory(from srcUrl: URL, to destUrl: URL, using client: SFTPClient, isCancelled: @escaping () -> Bool) async throws {
         // Create local directory
         try FileManager.default.createDirectory(at: destUrl, withIntermediateDirectories: true, attributes: nil)
-
+        
         // List and download children
         let contents = try await client.listDirectory(atPath: srcUrl.path)
         for name in contents {
@@ -616,7 +616,7 @@ class SftpFileSystem: NSObject, FileSystem {
                 let filename = component.filename
                 guard filename != "." && filename != ".." else { continue }
                 if isCancelled() { throw SftpError.operationCancelled }
-
+                
                 let isDir = component.attributes.permissions.map { $0 & 0o40000 != 0 } ?? false
                 let fileSrcUrl = srcUrl.appendingPathComponent(filename, isDirectory: isDir)
                 let fileDestUrl = destUrl.appendingPathComponent(filename, isDirectory: isDir)
@@ -624,22 +624,22 @@ class SftpFileSystem: NSObject, FileSystem {
             }
         }
     }
-
+    
     /// Upload a local file or directory to a remote destination.
     private func upload(from srcUrl: URL, to destUrl: URL, using client: SFTPClient, isCancelled: @escaping () -> Bool) async throws {
         assert(srcUrl.isFileURL, "Source URL (\(srcUrl)) expected to be local URL.")
         assert(isUnderRoot(destUrl), "Destination URL (\(destUrl)) expected to be under root (\(self.rootUrl)).")
-
+        
         if srcUrl.hasDirectoryPath {
             try await uploadDirectory(from: srcUrl, to: destUrl, using: client, isCancelled: isCancelled)
         } else {
             let finalDestUrl = try await nonExistingUrl(for: destUrl, using: client)
-
+            
             // Read local file
             let data = try Data(contentsOf: srcUrl)
-
+            
             if isCancelled() { throw SftpError.operationCancelled }
-
+            
             // Write to remote
             var buffer = ByteBuffer()
             buffer.writeBytes(data)
@@ -649,34 +649,34 @@ class SftpFileSystem: NSObject, FileSystem {
             }
         }
     }
-
+    
     /// Upload a local directory to a remote destination.
     private func uploadDirectory(from srcUrl: URL, to destUrl: URL, using client: SFTPClient, isCancelled: @escaping () -> Bool) async throws {
         // Create remote directory
         try await client.createDirectory(atPath: destUrl.path)
-
+        
         // List and upload children
         let contents = try FileManager.default.contentsOfDirectory(at: srcUrl, includingPropertiesForKeys: nil, options: [.skipsPackageDescendants, .skipsSubdirectoryDescendants])
-
+        
         for fileSrcUrl in contents {
             if isCancelled() { throw SftpError.operationCancelled }
             let fileDestUrl = fileSrcUrl.movedTo(destUrl)
             try await upload(from: fileSrcUrl, to: fileDestUrl, using: client, isCancelled: isCancelled)
         }
     }
-
+    
     /// Perform notification about starting to add new file.
     private func willAddFile(at url: URL, from fileOperation: FileOperation) {
         DispatchQueue.main.async {
             self.delegate?.fileSystem(self, willAddFileAt: url, from: fileOperation)
         }
     }
-
+    
     // MARK: Data Loading (Thumbnails)
-
+    
     func loadData(at url: URL, completionHandler: @escaping ((Data?, Error?) -> Void)) {
         assert(isUnderRoot(url), "URL (\(url)) is outside root tree (\(self.rootUrl)).")
-
+        
         // Task Duplicate Check
         downloadTasksLock.lock()
         if downloadTasks[url] != nil {
@@ -685,33 +685,33 @@ class SftpFileSystem: NSObject, FileSystem {
             return
         }
         downloadTasksLock.unlock()
-
+        
         let opCount = thumbnailQueue.operationCount
         Logger.filesystem.debug(">>> QUEUEING operation for \(url.lastPathComponent, privacy: .public). Current queue size: \(opCount, privacy: .public)")
-
+        
         let operation = BlockOperation()
-
+        
         operation.addExecutionBlock { [weak self, weak operation] in
             Logger.filesystem.debug(">>> STARTING operation for \(url.lastPathComponent, privacy: .public).")
-
+            
             guard let self = self, let strongOperation = operation, !strongOperation.isCancelled else {
                 Logger.filesystem.debug("SftpFileSystem loadData: Operation was nil or cancelled before starting for \(url.lastPathComponent, privacy: .public).")
                 DispatchQueue.main.async { completionHandler(nil, nil) }
                 return
             }
-
+            
             guard let pool = self.thumbnailPool else {
                 DispatchQueue.main.async { completionHandler(nil, SftpError.connectionFailed) }
                 return
             }
-
+            
             let semaphore = DispatchSemaphore(value: 0)
-
+            
             Task {
                 var session: SFTPClient?
                 var resultData: Data?
                 var resultError: Error?
-
+                
                 defer {
                     // Return session to pool
                     if let session = session {
@@ -719,36 +719,36 @@ class SftpFileSystem: NSObject, FileSystem {
                     }
                     semaphore.signal()
                 }
-
+                
                 do {
                     session = try await pool.acquire()
-
+                    
                     if strongOperation.isCancelled {
                         Logger.filesystem.debug("SftpFileSystem loadData: Operation cancelled after acquiring session for \(url.lastPathComponent, privacy: .public).")
                         return
                     }
-
+                    
                     Logger.filesystem.debug("SftpFileSystem loadData: Download starting for \(url.lastPathComponent, privacy: .public).")
-
+                    
                     let buffer = try await session!.withFile(filePath: url.path, flags: .read) { file in
                         try await file.readAll()
                     }
-
+                    
                     if strongOperation.isCancelled {
                         Logger.filesystem.debug("SftpFileSystem loadData: Operation cancelled after download for \(url.lastPathComponent, privacy: .public).")
                         return
                     }
-
+                    
                     resultData = Data(buffer: buffer)
                     Logger.filesystem.debug("SftpFileSystem loadData: Download complete. \(resultData?.count ?? 0, privacy: .public) bytes for \(url.lastPathComponent, privacy: .public).")
-
+                    
                 } catch {
                     if !strongOperation.isCancelled {
                         resultError = error
                         Logger.filesystem.error("SftpFileSystem loadData: Download failed for \(url.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)")
                     }
                 }
-
+                
                 if !strongOperation.isCancelled {
                     DispatchQueue.main.async {
                         completionHandler(resultData, resultError)
@@ -759,31 +759,31 @@ class SftpFileSystem: NSObject, FileSystem {
                     }
                 }
             }
-
+            
             semaphore.wait()
             Logger.filesystem.debug("SftpFileSystem loadData: <<< Operation FINISHED for \(url.lastPathComponent, privacy: .public) >>>")
         }
-
+        
         operation.completionBlock = { [weak self] in
             self?.downloadTasksLock.lock()
             self?.downloadTasks.removeValue(forKey: url)
             Logger.filesystem.debug("SftpFileSystem: Removed task for \(url.lastPathComponent, privacy: .public) from tracking. Remaining: \(self?.downloadTasks.count ?? 0, privacy: .public)")
             self?.downloadTasksLock.unlock()
         }
-
+        
         // Add the operation to the tracking dictionary before queueing it.
         downloadTasksLock.lock()
         downloadTasks[url] = operation
         downloadTasksLock.unlock()
-
+        
         thumbnailQueue.addOperation(operation)
     }
-
+    
     /// Cancels any queued or ongoing thumbnail download for the specified URL.
     public func cancelLoad(for url: URL) {
         downloadTasksLock.lock()
         defer { downloadTasksLock.unlock() }
-
+        
         if let operation = downloadTasks[url] {
             if !operation.isFinished && !operation.isCancelled {
                 operation.cancel()
@@ -797,28 +797,28 @@ class SftpFileSystem: NSObject, FileSystem {
 // MARK: - FileItem Extension for Citadel
 
 extension FileItem {
-
+    
     fileprivate convenience init?(sftpComponent: SFTPPathComponent, parentUrl: URL) {
         var name = sftpComponent.filename
         guard name != "." && name != ".." else { return nil }
         if name.hasSuffix("/") { name = String(name.dropLast()) }
-
+        
         let attrs = sftpComponent.attributes
         let isDir = attrs.permissions.map { $0 & 0o40000 != 0 } ?? false
-
+        
         let url = parentUrl.appendingPathComponent(name, isDirectory: isDir)
-
+        
         var flags: Flags = [.isReadable, .isWritable] // Assume readable/writable
         if isDir { flags.insert(.isDirectory) }
         if name.hasPrefix(".") { flags.insert(.isHidden) }
-
+        
         let fileType = flags.contains(.isDirectory) ? UTType.folder : UTType(filenameExtension: url.pathExtension) ?? .data
         let icon = NSWorkspace.shared.icon(for: fileType)
-
+        
         let fileSize = Int64(attrs.size ?? 0)
-
+        
         let modate: Date? = attrs.accessModificationTime?.modificationTime
-
+        
         self.init(url: url, name: name, icon: icon, flags: flags, fileSize: fileSize, modate: modate)
     }
 }

--- a/Soduto Files/Soduto-Files-Bridging-Header.h
+++ b/Soduto Files/Soduto-Files-Bridging-Header.h
@@ -1,5 +1,0 @@
-//
-//  Use this file to import your target's public headers that you would like to expose to Swift.
-//
-
-#import <NMSSH/NMSSH.h>

--- a/Soduto Files/Utils/Logger+Categories.swift
+++ b/Soduto Files/Utils/Logger+Categories.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2026 Soduto. All rights reserved.
 //
 
+import Foundation
 import os
 
 /// Logger categories for Soduto Files (SFTP browser) application.

--- a/Soduto.xcodeproj/project.pbxproj
+++ b/Soduto.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		312674CD2F2CE5C700D68B2C /* DeviceScrubberItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312674CC2F2CE5C700D68B2C /* DeviceScrubberItemView.swift */; };
 		312E77082938A93F00F29BFA /* Messages.png in Resources */ = {isa = PBXBuildFile; fileRef = 312E76FD2938A93F00F29BFA /* Messages.png */; };
 		313416CA2F381D44007E7640 /* X509 in Frameworks */ = {isa = PBXBuildFile; productRef = 313416C92F381D44007E7640 /* X509 */; };
+		313416CD2F3856C0007E7640 /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = 313416CC2F3856C0007E7640 /* Citadel */; };
 		3152C3F32F353AFA005152CB /* Logger+Categories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3152C3F22F353AFA005152CB /* Logger+Categories.swift */; };
 		3152C3F52F353B1E005152CB /* Logger+Categories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3152C3F42F353B1E005152CB /* Logger+Categories.swift */; };
 		3152C3F82F368F7B005152CB /* Logger+Categories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3152C3F72F368F7B005152CB /* Logger+Categories.swift */; };
@@ -425,6 +426,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				76A5B0D029320D230061BF0B /* NMSSH.xcframework in Frameworks */,
+				313416CD2F3856C0007E7640 /* Citadel in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -977,6 +979,7 @@
 			mainGroup = 843301571D2D8CB8008934BB;
 			packageReferences = (
 				313416C82F381D44007E7640 /* XCRemoteSwiftPackageReference "swift-certificates" */,
+				313416CB2F3856C0007E7640 /* XCRemoteSwiftPackageReference "Citadel" */,
 			);
 			productRefGroup = 843301611D2D8CB8008934BB /* Products */;
 			projectDirPath = "";
@@ -1778,6 +1781,14 @@
 				minimumVersion = 1.17.1;
 			};
 		};
+		313416CB2F3856C0007E7640 /* XCRemoteSwiftPackageReference "Citadel" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/orlandos-nl/Citadel";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.12.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1785,6 +1796,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 313416C82F381D44007E7640 /* XCRemoteSwiftPackageReference "swift-certificates" */;
 			productName = X509;
+		};
+		313416CC2F3856C0007E7640 /* Citadel */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 313416CB2F3856C0007E7640 /* XCRemoteSwiftPackageReference "Citadel" */;
+			productName = Citadel;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Soduto.xcodeproj/project.pbxproj
+++ b/Soduto.xcodeproj/project.pbxproj
@@ -270,7 +270,6 @@
 		76B580562930EE1B003453FD /* libssl.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libssl.a; path = Libraries/lib/libssl.a; sourceTree = "<group>"; };
 		76B580572930EE1B003453FD /* libssh2.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libssh2.a; path = Libraries/lib/libssh2.a; sourceTree = "<group>"; };
 		76B5805C2930EF31003453FD /* CocoaAsyncSocket.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CocoaAsyncSocket.xcframework; path = Carthage/Build/CocoaAsyncSocket.xcframework; sourceTree = "<group>"; };
-		76B5805D2930EF31003453FD /* NMSSH.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = NMSSH.xcframework; path = Carthage/Build/NMSSH.xcframework; sourceTree = "<group>"; };
 		8405381F1ED62282003798AA /* WelcomeWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeWindowController.swift; sourceTree = "<group>"; };
 		840FC2F81DEF6AF400AC4824 /* ClipboardService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClipboardService.swift; sourceTree = "<group>"; };
 		841E814C1D809C360096A846 /* Soduto.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Soduto.entitlements; sourceTree = "<group>"; };
@@ -774,7 +773,6 @@
 			children = (
 				31B189B529ED731B001C8735 /* Sparkle.framework */,
 				76B5805C2930EF31003453FD /* CocoaAsyncSocket.xcframework */,
-				76B5805D2930EF31003453FD /* NMSSH.xcframework */,
 				76B580552930EE1B003453FD /* libcrypto.a */,
 				76B580572930EE1B003453FD /* libssh2.a */,
 				76B580562930EE1B003453FD /* libssl.a */,

--- a/Soduto.xcodeproj/project.pbxproj
+++ b/Soduto.xcodeproj/project.pbxproj
@@ -51,9 +51,7 @@
 		31E1E1BD2F2C83DE002158D0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 31E1E1BC2F2C83DE002158D0 /* Assets.xcassets */; };
 		31F3A15C293B5EA300550088 /* Soduto Share.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 31F3A14F293B5EA300550088 /* Soduto Share.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		31F3A1AF293BDAF400550088 /* ShareExtensionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F3A153293B5EA300550088 /* ShareExtensionController.swift */; };
-		761FBEF3293211C50034FD44 /* NMSSH.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 76B5805D2930EF31003453FD /* NMSSH.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		761FBEF5293212580034FD44 /* CocoaAsyncSocket.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 76B5805C2930EF31003453FD /* CocoaAsyncSocket.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		76A5B0D029320D230061BF0B /* NMSSH.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 76B5805D2930EF31003453FD /* NMSSH.xcframework */; settings = {ATTRIBUTES = (Required, ); }; };
 		76B580582930EE1B003453FD /* libcrypto.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 76B580552930EE1B003453FD /* libcrypto.a */; };
 		76B580592930EE1B003453FD /* libssl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 76B580562930EE1B003453FD /* libssl.a */; };
 		76B5805A2930EE1B003453FD /* libssh2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 76B580572930EE1B003453FD /* libssh2.a */; };
@@ -174,17 +172,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		023BD5A2204AEE270045B5F9 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				761FBEF3293211C50034FD44 /* NMSSH.xcframework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		31F3A15D293B5EA300550088 /* Embed Foundation Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -424,7 +411,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				76A5B0D029320D230061BF0B /* NMSSH.xcframework in Frameworks */,
 				313416CD2F3856C0007E7640 /* Citadel in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -885,7 +871,6 @@
 				845BC7061E69F00E00DC9B81 /* Sources */,
 				845BC7071E69F00E00DC9B81 /* Frameworks */,
 				845BC7081E69F00E00DC9B81 /* Resources */,
-				023BD5A2204AEE270045B5F9 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/Soduto.xcodeproj/project.pbxproj
+++ b/Soduto.xcodeproj/project.pbxproj
@@ -369,7 +369,6 @@
 		849962121D572B1F002B893A /* Logging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Logging.m; path = MYUtilities/Logging.m; sourceTree = "<group>"; };
 		84A16BDF1E9EBADD00DE2C0B /* Sequence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sequence.swift; sourceTree = "<group>"; };
 		84C545DF1EABC14E005A8107 /* SftpFileSystem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SftpFileSystem.swift; sourceTree = "<group>"; };
-		84C545F71EABECDE005A8107 /* Soduto-Files-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Soduto-Files-Bridging-Header.h"; sourceTree = "<group>"; };
 		84C613E21DECBF6B00CE7F7A /* UploadTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UploadTask.swift; sourceTree = "<group>"; };
 		84D903A11DC696A600E61DA7 /* CertificateUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CertificateUtils.swift; sourceTree = "<group>"; };
 		84FA45CF1DDDCB3D00EF3992 /* Connection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Connection.swift; sourceTree = "<group>"; };
@@ -685,7 +684,6 @@
 				8440FD061E6CA6CA00E5BFA9 /* LocalFileSystem.swift */,
 				845BC7101E69F00E00DC9B81 /* MainMenu.xib */,
 				84C545DF1EABC14E005A8107 /* SftpFileSystem.swift */,
-				84C545F71EABECDE005A8107 /* Soduto-Files-Bridging-Header.h */,
 				8438ECE01EBA650A006CBB07 /* Soduto_Files.entitlements */,
 				845847201E75D0ED00EE5A09 /* Utils */,
 			);
@@ -1633,7 +1631,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/Soduto/OpenSSL/openssl/include";
-				SWIFT_OBJC_BRIDGING_HEADER = "Soduto Files/Soduto-Files-Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 5.0;
 			};
@@ -1663,7 +1660,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/Soduto/OpenSSL/openssl/include";
-				SWIFT_OBJC_BRIDGING_HEADER = "Soduto Files/Soduto-Files-Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 5.0;
 			};

--- a/Soduto/Acknowledgements.html
+++ b/Soduto/Acknowledgements.html
@@ -19,6 +19,50 @@
 
 <p>Soduto includes 3rd party software with the following licensing information:</p>
 
+<h1 id="bigint">BigInt</h1>
+
+<p>Copyright (c) 2016-2017 Károly Lőrentey</p>
+
+<p>Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:</p>
+
+<p>The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.</p>
+
+<p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</p>
+
+<h1 id="citadel">Citadel</h1>
+
+<p>Copyright (c) 2022 Orlandos</p>
+
+<p>Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:</p>
+
+<p>The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.</p>
+
+<p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</p>
+
 <h1 id="cocoaasyncsocket">CocoaAsyncSocket</h1>
 
 <p>This library is in the public domain.</p>
@@ -100,28 +144,6 @@ BUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CO
 PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
-
-<h1 id="nmssh">NMSSH</h1>
-
-<p>Copyright (c) 2013 Nine Muses AB</p>
-
-<p>Permission is hereby granted, free of charge, to any person obtaining
- a copy of this software and associated documentation files (the
-“Software”), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:</p>
-
-<p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
-
-<p>THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
 
 <h1 id="openssl">OpenSSL</h1>
 
@@ -391,6 +413,31 @@ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.</p>
+
+<h1 id="swift-packages">Swift Packages (Apple)</h1>
+
+<p>The following Swift packages are licensed under the Apache License 2.0:</p>
+
+<ul>
+  <li>swift-atomics</li>
+  <li>swift-collections</li>
+  <li>swift-log</li>
+  <li>swift-nio</li>
+  <li>swift-nio-ssh</li>
+  <li>swift-system</li>
+</ul>
+
+<p>Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at</p>
+
+<p><a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a></p>
+
+<p>Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.</p>
 
 </body>
 </html>

--- a/Soduto/Core/Utils/Logger+Categories.swift
+++ b/Soduto/Core/Utils/Logger+Categories.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2026 Soduto. All rights reserved.
 //
 
+import Foundation
 import os
 
 /// Logger categories for Soduto main application.


### PR DESCRIPTION
This pull request removes the [`NMSSH`](https://github.com/sannidhyaroy/NMSSH) dependency from the project and migrates SFTP functionality to the [`Citadel`](https://github.com/orlandos-nl/Citadel) Swift package. It updates the project configuration and documentation to reflect this change, and adds new acknowledgements for `Citadel` and it's swift dependencies.

### Dependency migration and project configuration

- Removed `NMSSH` dependency from `Cartfile`, project files, and build phases
- Added `Citadel` as a Swift package dependency
- Removed `NMSSH` bridging header and related imports from `Soduto-Files-Bridging-Header.h` and project configuration

### Codebase updates for migration

- Removed `NMSSH` logging initialization from `AppDelegate.swift`
- Updated SFTP connection logic in `AppDelegate.swift` to use asynchronous creation, compatible with `Citadel`

### Documentation and acknowledgements

- Updated `README.md` to remove NMSSH-specific troubleshooting and references
- Added `Citadel` and it's Swift dependencies' package license information to `Acknowledgements.html`
- Removed `NMSSH` license information from `Acknowledgements.html`

### Minor Improvements

- Added missing `Foundation` import in `Logger+Categories.swift` of both `Soduto` and `Soduto Files` target. Previously it worked via transitive import from bridging headers (`imports IO.h` which has `#import <Foundation/Foundation.h>`), but explicit imports are more robust