### PR TITLE
chore(macos): bump minimum macOS target to 14.0

### DIFF
--- a/Soduto Files/BrowserWindowController.swift
+++ b/Soduto Files/BrowserWindowController.swift
@@ -125,7 +125,7 @@ class BrowserWindowController: NSWindowController {
     
     override var windowNibName: String? { return "BrowserWindow" }
     
-    fileprivate static let dropTypes: [NSPasteboard.PasteboardType] = [ NSPasteboard.PasteboardType(rawValue: kUTTypeURL as String) ]
+    fileprivate static let dropTypes: [NSPasteboard.PasteboardType] = [ NSPasteboard.PasteboardType(UTType.url.identifier) ]
     private static var userDefaults: UserDefaults = {
         // Setup user settings default values
         UserDefaults.standard.register(defaults: [
@@ -284,7 +284,7 @@ class BrowserWindowController: NSWindowController {
             guard component != "/" else { continue }
             url.appendPathComponent(component, isDirectory: true)
             let cell = NSPathComponentCell()
-            cell.image = NSWorkspace.shared.icon(forFileType: kUTTypeFolder as String)
+            cell.image = NSWorkspace.shared.icon(for: .folder)
             cell.title = component.removingPercentEncoding ?? component
             cell.url = url
             cells.append(cell)
@@ -292,7 +292,7 @@ class BrowserWindowController: NSWindowController {
         
         if self.collectionView.selectionIndexPaths.count == 1, let fileItem = self.fileItem(at: self.collectionView.selectionIndexPaths.first!), fileItem.isDirectory {
             let cell = NSPathComponentCell()
-            cell.image = NSWorkspace.shared.icon(forFileType: kUTTypeFolder as String)
+            cell.image = NSWorkspace.shared.icon(for: .folder)
             cell.title = fileItem.name.removingPercentEncoding ?? fileItem.name
             cell.url = fileItem.url
             cells.append(cell)

--- a/Soduto Files/FileItem.swift
+++ b/Soduto Files/FileItem.swift
@@ -9,6 +9,7 @@
 import Foundation
 import AppKit
 import os
+import UniformTypeIdentifiers
 
 public class FileItem: NSObject, NSPasteboardReading, NSPasteboardWriting {
     
@@ -88,8 +89,8 @@ public class FileItem: NSObject, NSPasteboardReading, NSPasteboardWriting {
             var flags: Flags = [.isReadable, .isWritable]
             if url.hasDirectoryPath { flags.insert(.isDirectory) }
             if url.lastPathComponent.hasPrefix(".") { flags.insert(.isHidden) }
-            let fileType: String = flags.contains(.isDirectory) ? String(kUTTypeDirectory) : url.pathExtension
-            let icon = flags.contains(.isDirectory) ? NSWorkspace.shared.icon(forFileType: kUTTypeFolder as String) : NSWorkspace.shared.icon(forFileType: fileType)
+            let fileType = flags.contains(.isDirectory) ? UTType.folder : UTType(filenameExtension: url.pathExtension) ?? .data
+            let icon = NSWorkspace.shared.icon(for: fileType)
             self.init(url: url, name: name, icon: icon, flags: flags, fileSize: 0, modate: nil)
             
         }
@@ -104,38 +105,38 @@ public class FileItem: NSObject, NSPasteboardReading, NSPasteboardWriting {
                 return [
                     NSPasteboard.PasteboardType(rawValue: kPasteboardTypeFileURLPromise),
                     NSPasteboard.PasteboardType(rawValue: kPasteboardTypeFilePromiseContent),
-                    NSPasteboard.PasteboardType(rawValue: kUTTypeDirectory as String),
-                    NSPasteboard.PasteboardType(rawValue: kUTTypeFileURL as String),
-                    NSPasteboard.PasteboardType(rawValue: kUTTypeURL as String) ]
+                    NSPasteboard.PasteboardType(UTType.directory.identifier),
+                    NSPasteboard.PasteboardType(UTType.fileURL.identifier),
+                    NSPasteboard.PasteboardType(UTType.url.identifier) ]
             }
             else {
                 return [
                     NSPasteboard.PasteboardType(rawValue: kPasteboardTypeFileURLPromise),
                     NSPasteboard.PasteboardType(rawValue: kPasteboardTypeFilePromiseContent),
-                    NSPasteboard.PasteboardType(rawValue: kUTTypeFileURL as String),
-                    NSPasteboard.PasteboardType(rawValue: kUTTypeURL as String) ]
+                    NSPasteboard.PasteboardType(UTType.fileURL.identifier),
+                    NSPasteboard.PasteboardType(UTType.url.identifier) ]
             }
         }
         else {
             return [
                 NSPasteboard.PasteboardType(rawValue: kPasteboardTypeFileURLPromise),
                 NSPasteboard.PasteboardType(rawValue: kPasteboardTypeFilePromiseContent),
-                NSPasteboard.PasteboardType(rawValue: kUTTypeURL as String) ]
+                NSPasteboard.PasteboardType(UTType.url.identifier) ]
         }
     }
     
     public func pasteboardPropertyList(forType type: NSPasteboard.PasteboardType) -> Any? {
         switch type.rawValue {
-        case String(kUTTypeDirectory):
+        case UTType.directory.identifier:
             guard self.url.isFileURL && self.isDirectory else { return nil }
             return self.url.path
-        case String(kUTTypeFileURL):
+        case UTType.fileURL.identifier:
             guard self.url.isFileURL else { return nil }
             return (self.url as NSURL).pasteboardPropertyList(forType: type)
-        case String(kUTTypeURL):
+        case UTType.url.identifier:
             return (self.url as NSURL).pasteboardPropertyList(forType: type)
         case String(kPasteboardTypeFilePromiseContent):
-            return  kUTTypeBMP
+            return UTType.bmp.identifier
         case String(kPasteboardTypeFileURLPromise):
             return nil
         default:
@@ -147,7 +148,7 @@ public class FileItem: NSObject, NSPasteboardReading, NSPasteboardWriting {
     // MARK: NSPasteboardReading
     
     public static func readableTypes(for pasteboard: NSPasteboard) -> [NSPasteboard.PasteboardType] {
-        return [ kUTTypeURL as NSPasteboard.PasteboardType ]
+        return [ NSPasteboard.PasteboardType(UTType.url.identifier) ]
     }
     
     public static func readingOptions(forType type: NSPasteboard.PasteboardType, pasteboard: NSPasteboard) -> NSPasteboard.ReadingOptions {

--- a/Soduto Files/FileSystem.swift
+++ b/Soduto Files/FileSystem.swift
@@ -29,7 +29,7 @@ struct Place {
     }
 }
 
-class FileOperation: BlockOperation {
+class FileOperation: BlockOperation, @unchecked Sendable {
     
     enum FileState {
         case unchanged

--- a/Soduto Files/SftpFileSystem.swift
+++ b/Soduto Files/SftpFileSystem.swift
@@ -9,6 +9,7 @@
 import Foundation
 import os
 import Cocoa
+import UniformTypeIdentifiers
 
 class SftpFileSystem: NSObject, FileSystem, NMSSHSessionDelegate {
     private let thumbnailConcurrentOprationCount = 16
@@ -662,8 +663,8 @@ extension FileItem {
         if sftpFile.isDirectory { flags.insert(.isDirectory) }
         if name.hasPrefix(".") { flags.insert(.isHidden) }
         
-        let fileType: String = flags.contains(.isDirectory) ? String(kUTTypeDirectory) : url.pathExtension
-        let icon = flags.contains(.isDirectory) ? NSWorkspace.shared.icon(forFileType: kUTTypeFolder as String) : NSWorkspace.shared.icon(forFileType: fileType)
+        let fileType = flags.contains(.isDirectory) ? UTType.folder : UTType(filenameExtension: url.pathExtension) ?? .data
+        let icon = NSWorkspace.shared.icon(for: fileType)
         
         let fileSize = sftpFile.fileSize?.int64Value ?? 0
         

--- a/Soduto Share/Views/ShareSheetView.swift
+++ b/Soduto Share/Views/ShareSheetView.swift
@@ -226,7 +226,7 @@ struct DeviceBubble: View {
         .onHover { hovering in
             isHovering = hovering
         }
-        .onChange(of: status) { newStatus in
+        .onChange(of: status) { oldStatus, newStatus in
             switch newStatus {
             case .transferring:
                 showFlashOverlay = false

--- a/Soduto.xcodeproj/project.pbxproj
+++ b/Soduto.xcodeproj/project.pbxproj
@@ -1309,7 +1309,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 3.1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -1350,7 +1350,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 3.1.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.soduto.Soduto.Soduto-Share";
@@ -1415,7 +1415,7 @@
 					"$(PROJECT_DIR)/Libraries/include/libssh2",
 					"$(PROJECT_DIR)/Libraries/include",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -1472,7 +1472,7 @@
 					"$(PROJECT_DIR)/Libraries/include/libssh2",
 					"$(PROJECT_DIR)/Libraries/include",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -1508,7 +1508,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Libraries/lib",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 3.1.0;
 				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies=500";
 				PRODUCT_BUNDLE_IDENTIFIER = com.soduto.Soduto;
@@ -1549,7 +1549,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Libraries/lib",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 3.1.0;
 				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies=500";
 				PRODUCT_BUNDLE_IDENTIFIER = com.soduto.Soduto;
@@ -1625,7 +1625,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 3.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.soduto.Soduto-Files";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1655,7 +1655,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 3.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.soduto.Soduto-Files";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Soduto/Core/CertificateUtils.swift
+++ b/Soduto/Core/CertificateUtils.swift
@@ -257,35 +257,24 @@ public class CertificateUtils {
     }
     
     private class func generateRSAKeyPair(sizeInBits: Int, permanent: Bool, label: String) throws -> (SecKey, SecKey) {
-#if os(iOS)
-        let keyAttrs: [String: AnyObject] = [
-            kSecAttrIsPermanent as String: permanent as AnyObject,
-            kSecAttrLabel as String: label as AnyObject
-        ]
-        let pairAttrs: [String: AnyObject] = [
+        let attributes: [String: Any] = [
             kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
-            kSecAttrKeySizeInBits as String: sizeInBits as AnyObject,
-            kSecAttrLabel as String: label as AnyObject,
-            kSecPublicKeyAttrs as String: keyAttrs as AnyObject,
-            kSecPrivateKeyAttrs as String: keyAttrs as AnyObject
+            kSecAttrKeySizeInBits as String: sizeInBits,
+            kSecAttrLabel as String: label,
+            kSecAttrIsPermanent as String: permanent
         ]
-#else
-        let pairAttrs: [String: AnyObject] = [
-            kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
-            kSecAttrKeySizeInBits as String: sizeInBits as AnyObject,
-            kSecAttrLabel as String: label as AnyObject,
-            kSecAttrIsPermanent as String: permanent as AnyObject
-        ]
-#endif
-        var publicKey: SecKey? = nil
-        var privateKey: SecKey? = nil
-        let status = SecKeyGeneratePair(pairAttrs as CFDictionary, &publicKey, &privateKey)
-        if status == noErr {
-            return (publicKey!, privateKey!)
-        }
-        else {
+        
+        var error: Unmanaged<CFError>?
+        guard let privateKey = SecKeyCreateRandomKey(attributes as CFDictionary, &error) else {
+            let status = error.map { Int32(CFErrorGetCode($0.takeRetainedValue())) } ?? errSecInternalError
             throw CertificateError.generateRSAKeyPairFailure(status: status)
         }
+        
+        guard let publicKey = SecKeyCopyPublicKey(privateKey) else {
+            throw CertificateError.generateRSAKeyPairFailure(status: errSecInternalError)
+        }
+        
+        return (publicKey, privateKey)
     }
     
     public class func createIdentity(label: String, certCommonName: String, expirationInterval: TimeInterval) throws -> SecIdentity? {

--- a/Soduto/Core/Connection.swift
+++ b/Soduto/Core/Connection.swift
@@ -603,7 +603,8 @@ public class Connection: NSObject, GCDAsyncSocketDelegate, PairingHandlerDelegat
     private func shouldTrustPeer(_ trust: SecTrust) -> Bool {
         assert(self.identity != nil, "Identity expected to be known before securing connection and evaluating trust")
         
-        guard let peerCertificate = SecTrustGetCertificateAtIndex(trust, 0) else { return false }
+        guard let certificateChain = SecTrustCopyCertificateChain(trust) as? [SecCertificate],
+              let peerCertificate = certificateChain.first else { return false }
         self.peerCertificate = peerCertificate
         
         if self.pairingHandler!.pairingStatus == .Paired {

--- a/Soduto/Core/DownloadTask.swift
+++ b/Soduto/Core/DownloadTask.swift
@@ -200,7 +200,8 @@ public class DownloadTask: NSObject, GCDAsyncSocketDelegate {
     }
     
     private func shoulTrustPeer(_ trust: SecTrust) -> Bool {
-        guard let peerCertificate = SecTrustGetCertificateAtIndex(trust, 0) else { return false }
+        guard let certificateChain = SecTrustCopyCertificateChain(trust) as? [SecCertificate],
+              let peerCertificate = certificateChain.first else { return false }
         return self.connection.shouldTrustPeerCertificate(peerCertificate)
     }
 }

--- a/Soduto/Core/UploadTask.swift
+++ b/Soduto/Core/UploadTask.swift
@@ -250,7 +250,8 @@ public class UploadTask: NSObject, GCDAsyncSocketDelegate {
     }
     
     private func shoulTrustPeer(_ trust: SecTrust) -> Bool {
-        guard let peerCertificate = SecTrustGetCertificateAtIndex(trust, 0) else { return false }
+        guard let certificateChain = SecTrustCopyCertificateChain(trust) as? [SecCertificate],
+              let peerCertificate = certificateChain.first else { return false }
         return self.connection.shouldTrustPeerCertificate(peerCertificate)
     }
 }

--- a/Soduto/Services/ShareService.swift
+++ b/Soduto/Services/ShareService.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Cocoa
 import os
+import UniformTypeIdentifiers
 import UserNotifications
 
 /// Service providing capability to send end receive files, links, etc
@@ -95,10 +96,10 @@ public class ShareService: NSObject, Service, DownloadTaskDelegate, ConnectionDe
     public static let serviceId: Service.Id = "com.soduto.services.share"
     
     private static let dragTypes: [NSPasteboard.PasteboardType] = [
-        NSPasteboard.PasteboardType(rawValue: kUTTypeFileURL as String),
-        NSPasteboard.PasteboardType(rawValue: kUTTypeURL as String),
-        NSPasteboard.PasteboardType(rawValue: kUTTypeUTF8PlainText as String),
-        NSPasteboard.PasteboardType(rawValue: kUTTypeText as String)]
+        NSPasteboard.PasteboardType(UTType.fileURL.identifier),
+        NSPasteboard.PasteboardType(UTType.url.identifier),
+        NSPasteboard.PasteboardType(UTType.utf8PlainText.identifier),
+        NSPasteboard.PasteboardType(UTType.text.identifier)]
     
     public let incomingCapabilities = Set<Service.Capability>([ DataPacket.sharePacketType ])
     public let outgoingCapabilities = Set<Service.Capability>([ DataPacket.sharePacketType ])
@@ -314,21 +315,21 @@ public class ShareService: NSObject, Service, DownloadTaskDelegate, ConnectionDe
             guard let type = item.availableType(from: types) else { continue }
             switch type.rawValue {
                 
-            case String(kUTTypeFileURL):
+            case UTType.fileURL.identifier:
                 guard let urlString = item.string(forType: type) else { break }
                 guard let url = URL(string: urlString) else { break }
                 guard let dataPacket = self.dataPacket(forFileUrl: url) else { break }
                 filePackets.append(dataPacket)
                 break
                 
-            case String(kUTTypeURL):
+            case UTType.url.identifier:
                 guard let urlString = item.string(forType: type) else { break }
                 guard let url = URL(string: urlString) else { break }
                 let dataPacket = self.dataPacket(forUrl: url)
                 urlPackets.append(dataPacket)
                 break
                 
-            case type.rawValue where UTTypeConformsTo(type.rawValue as CFString, kUTTypeText):
+            case type.rawValue where UTType(type.rawValue)?.conforms(to: .text) == true:
                 guard let text = item.string(forType: type) else { break }
                 if let url = URL(string: text), url.scheme != nil {
                     let dataPacket = self.dataPacket(forUrl: url)

--- a/Soduto/UI/Controllers/SendMessageWindowController.swift
+++ b/Soduto/UI/Controllers/SendMessageWindowController.swift
@@ -10,6 +10,7 @@ import Foundation
 import Cocoa
 import Contacts
 import os
+import UniformTypeIdentifiers
 
 class SendMessageWindowController: NSWindowController {
     
@@ -428,14 +429,14 @@ extension ContactPhoneNumber: NSPasteboardWriting {
     func writableTypes(for pasteboard: NSPasteboard) -> [NSPasteboard.PasteboardType] {
         return [
             ContactPhoneNumber.pboardType,
-            NSPasteboard.PasteboardType(rawValue: kUTTypeText as String) ]
+            NSPasteboard.PasteboardType(UTType.text.identifier) ]
     }
     
     func pasteboardPropertyList(forType type: NSPasteboard.PasteboardType) -> Any? {
         if type == ContactPhoneNumber.pboardType {
             return self.canonicalString
         }
-        else if type.rawValue == kUTTypeText as String {
+        else if type.rawValue == UTType.text.identifier {
             return self.canonicalString
         }
         else {

--- a/Soduto/UI/Controllers/StatusBarMenuController.swift
+++ b/Soduto/UI/Controllers/StatusBarMenuController.swift
@@ -9,6 +9,7 @@
 import Foundation
 import AppKit
 import ServiceManagement
+import UniformTypeIdentifiers
 
 public class StatusBarMenuController: NSObject, NSWindowDelegate, NSMenuDelegate, NSDraggingDestination {
     
@@ -43,8 +44,8 @@ public class StatusBarMenuController: NSObject, NSWindowDelegate, NSMenuDelegate
         self.statusBarItem.menu = self.statusBarMenu
         
         let dragTypes: [NSPasteboard.PasteboardType] = [
-            NSPasteboard.PasteboardType(rawValue: kUTTypeURL as String),
-            NSPasteboard.PasteboardType(rawValue: kUTTypeText as String) ]
+            NSPasteboard.PasteboardType(UTType.url.identifier),
+            NSPasteboard.PasteboardType(UTType.text.identifier) ]
         self.statusBarItem.button?.window?.registerForDraggedTypes(dragTypes)
         self.statusBarItem.button?.window?.delegate = self
     }


### PR DESCRIPTION
## Summary

- Raises minimum deployment target from macOS 11 to macOS 14.0
- Fixes deprecation warnings for APIs replaced in macOS 14+

## Changes

- Updated project deployment target settings
- Addressed deprecation warnings

## Testing

- [x] Builds successfully on macOS 14.0+
- [x] Application runs without warnings

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)