### PR TITLE
refactor(sparkle): migrate sparkle integration from carthage to swift package manager

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,1 @@
 github "sannidhyaroy/CocoaAsyncSocket" "master"
-binary "https://sparkle-project.org/Carthage/Sparkle.json"

--- a/README.md
+++ b/README.md
@@ -75,9 +75,6 @@ Do note that currently there's no Homebrew formulae for my forked version and th
 >  ```
 >  *** Skipped downloading CocoaAsyncSocket binary due to the error:
 >      "Bad credentials"
->  *** Downloading binary-only framework Sparkle at "https://sparkle-project.org/Carthage/Sparkle.json"
->  *** Skipped downloading CocoaAsyncSocket binary due to the error:
->      "Bad credentials"
 >  ```
 >
 >  This is likely due to GitHub Rate Limits. You can create a [GitHub Token](https://github.com/settings/tokens) and export it as an environment variable (format: `ghp_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`):
@@ -86,7 +83,7 @@ Do note that currently there's no Homebrew formulae for my forked version and th
 >  ```
 
 * Open project `Soduto.xcodeproj` with Xcode (select the Soduto Application in Xcode Project Navigator).
-  - Swift Package dependencies (Citadel, swift-nio, swift-certificates, etc.) will resolve automatically on first build.
+  - Swift Package dependencies (Sparkle, Citadel, swift-certificates, etc.) will resolve automatically on first build.
 * Select `Soduto` as Target. Go to `Signing & Capabilities` and under the `Signing` section, ensure your appropriate `Team` is selected.
 * Make sure you have the same `App Group key` for `Soduto Share` and also verify that the same `Team` is selected for each target.
 * Build target `Soduto`

--- a/Soduto.xcodeproj/project.pbxproj
+++ b/Soduto.xcodeproj/project.pbxproj
@@ -46,8 +46,6 @@
 		319CBA2A2939F07D00DAE301 /* AirDrop.png in Resources */ = {isa = PBXBuildFile; fileRef = 319CBA292939F07D00DAE301 /* AirDrop.png */; };
 		31A0A3C02F2C118F00CDA243 /* ShareSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A0A3BF2F2C118F00CDA243 /* ShareSheetView.swift */; };
 		31A0A3C52F2C7C6100CDA243 /* ShareSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A0A3BF2F2C118F00CDA243 /* ShareSheetView.swift */; };
-		31B189B729ED73A1001C8735 /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 31B189B529ED731B001C8735 /* Sparkle.framework */; };
-		31B189B829ED73A1001C8735 /* Sparkle.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 31B189B529ED731B001C8735 /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		31DB2F072F3BE86300654096 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 31DB2F062F3BE86300654096 /* Sparkle */; };
 		31E1E1BD2F2C83DE002158D0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 31E1E1BC2F2C83DE002158D0 /* Assets.xcassets */; };
 		31F3A15C293B5EA300550088 /* Soduto Share.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 31F3A14F293B5EA300550088 /* Soduto Share.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -219,7 +217,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				761FBEF5293212580034FD44 /* CocoaAsyncSocket.xcframework in Embed Frameworks */,
-				31B189B829ED73A1001C8735 /* Sparkle.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -384,7 +381,6 @@
 			files = (
 				313416CA2F381D44007E7640 /* X509 in Frameworks */,
 				31DB2F072F3BE86300654096 /* Sparkle in Frameworks */,
-				31B189B729ED73A1001C8735 /* Sparkle.framework in Frameworks */,
 				843E17891E26B56A001D0444 /* ServiceManagement.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Soduto.xcodeproj/project.pbxproj
+++ b/Soduto.xcodeproj/project.pbxproj
@@ -254,7 +254,6 @@
 		319CBA272939662400DAE301 /* Phone.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Phone.png; sourceTree = "<group>"; };
 		319CBA292939F07D00DAE301 /* AirDrop.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AirDrop.png; sourceTree = "<group>"; };
 		31A0A3BF2F2C118F00CDA243 /* ShareSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheetView.swift; sourceTree = "<group>"; };
-		31B189B529ED731B001C8735 /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sparkle.framework; path = Carthage/Build/Mac/Sparkle.framework; sourceTree = "<group>"; };
 		31E1E1BC2F2C83DE002158D0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		31F3A14F293B5EA300550088 /* Soduto Share.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Soduto Share.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		31F3A153293B5EA300550088 /* ShareExtensionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionController.swift; sourceTree = "<group>"; };
@@ -755,7 +754,6 @@
 		849962261D574530002B893A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				31B189B529ED731B001C8735 /* Sparkle.framework */,
 				76B5805C2930EF31003453FD /* CocoaAsyncSocket.xcframework */,
 				843E17881E26B56A001D0444 /* ServiceManagement.framework */,
 			);

--- a/Soduto.xcodeproj/project.pbxproj
+++ b/Soduto.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		31A0A3C52F2C7C6100CDA243 /* ShareSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A0A3BF2F2C118F00CDA243 /* ShareSheetView.swift */; };
 		31B189B729ED73A1001C8735 /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 31B189B529ED731B001C8735 /* Sparkle.framework */; };
 		31B189B829ED73A1001C8735 /* Sparkle.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 31B189B529ED731B001C8735 /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		31DB2F072F3BE86300654096 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 31DB2F062F3BE86300654096 /* Sparkle */; };
 		31E1E1BD2F2C83DE002158D0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 31E1E1BC2F2C83DE002158D0 /* Assets.xcassets */; };
 		31F3A15C293B5EA300550088 /* Soduto Share.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 31F3A14F293B5EA300550088 /* Soduto Share.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		31F3A1AF293BDAF400550088 /* ShareExtensionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F3A153293B5EA300550088 /* ShareExtensionController.swift */; };
@@ -382,6 +383,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				313416CA2F381D44007E7640 /* X509 in Frameworks */,
+				31DB2F072F3BE86300654096 /* Sparkle in Frameworks */,
 				31B189B729ED73A1001C8735 /* Sparkle.framework in Frameworks */,
 				843E17891E26B56A001D0444 /* ServiceManagement.framework in Frameworks */,
 			);
@@ -944,6 +946,7 @@
 			packageReferences = (
 				313416C82F381D44007E7640 /* XCRemoteSwiftPackageReference "swift-certificates" */,
 				313416CB2F3856C0007E7640 /* XCRemoteSwiftPackageReference "Citadel" */,
+				31DB2F052F3BE86300654096 /* XCRemoteSwiftPackageReference "Sparkle" */,
 			);
 			productRefGroup = 843301611D2D8CB8008934BB /* Products */;
 			projectDirPath = "";
@@ -1738,6 +1741,14 @@
 				minimumVersion = 0.12.0;
 			};
 		};
+		31DB2F052F3BE86300654096 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.8.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1750,6 +1761,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 313416CB2F3856C0007E7640 /* XCRemoteSwiftPackageReference "Citadel" */;
 			productName = Citadel;
+		};
+		31DB2F062F3BE86300654096 /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 31DB2F052F3BE86300654096 /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
## Summary
This pull request migrates the integration of the Sparkle framework from a Carthage binary dependency to a Swift Package Manager (SPM) dependency. This change simplifies dependency management and aligns with modern best practices for macOS/iOS projects. The most important changes are:

### Dependency Management Updates

- Removed the binary-only Sparkle framework from `Cartfile` and project references, eliminating the need to download and manage the binary manually
- Added Sparkle as a Swift Package dependency in the Xcode project, including the appropriate package reference and product dependency configuration

### Project Configuration Adjustments

- Updated framework embedding and linking in the Xcode project to use the SPM-provided Sparkle framework instead of the Carthage binary

### Documentation

- Updated the `README.md` to reflect that Sparkle is now resolved via Swift Package Manager rather than Carthage, and removed outdated Carthage error messages related to Sparkle